### PR TITLE
chore: harden CI pipeline and apply project-review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,17 @@
 name: CI
 
 on:
+  # Note: NO trigger-level `paths-ignore`. Under Repository Rulesets requiring
+  # `ci-pass`, doc-only changes filtered at the trigger level produce no
+  # workflow run → no `ci-pass` status → required check reports "expected,
+  # not received" indefinitely (admin override is also rejected). Path
+  # filtering is moved into the `changes` job below; doc-only changes still
+  # produce a green `ci-pass` because heavy jobs are skipped (skipped !=
+  # failed) and `ci-pass` only blocks on failure/cancelled.
   push:
     branches: [main]
     tags: ['v*']
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
   pull_request:
-    branches: [main]
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
   schedule:
     # Weekly CVE scan — Mondays 04:00 UTC
     - cron: '0 4 * * 1'
@@ -46,9 +24,53 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read   # dorny/paths-filter needs this on PR events
+
+env:
+  # Tracked by Renovate via the workflow customManager in renovate.json — bumped
+  # in tandem with the Makefile `ZAP_VERSION` (same depName + currentValue, so
+  # the bumps land in a single PR by default).
+  # renovate: datasource=github-releases depName=zaproxy/zaproxy extractVersion=^v(?<version>.*)$
+  ZAP_VERSION: 2.17.0
 
 jobs:
+  changes:
+    # Detect whether the change set includes any code paths. Heavy jobs gate
+    # on `needs.changes.outputs.code == 'true'`; doc-only changes skip them.
+    # On tag pushes, schedules, and workflow_dispatch we force code=true so
+    # release / CVE scan / manual runs are never skipped by accident.
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      code: ${{ steps.combine.outputs.code }}
+    steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Filter changed paths
+        id: filter
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
+              - 'CLAUDE.md'
+
+      - name: Combine signal
+        id: combine
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
   static-check:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -57,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0  # gitleaks needs full git history
 
-      - name: Set up mise
+      - name: Set up toolchain (mise)
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -74,14 +96,15 @@ jobs:
         run: make static-check
 
   build:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up mise
+      - name: Set up toolchain (mise)
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -98,14 +121,15 @@ jobs:
         run: make build
 
   test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up mise
+      - name: Set up toolchain (mise)
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -122,14 +146,15 @@ jobs:
         run: make test
 
   integration-test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up mise
+      - name: Set up toolchain (mise)
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -146,14 +171,15 @@ jobs:
         run: make integration-test
 
   e2e:
-    needs: [build, test]
+    needs: [changes, build, test]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up mise
+      - name: Set up toolchain (mise)
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -172,15 +198,15 @@ jobs:
   cve-check:
     # Runs on tags (release gate), weekly schedule, or manual dispatch.
     # Skipped on normal pushes/PRs — slow path can take 15+ min without NVD_API_KEY.
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true' && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up mise
+      - name: Set up toolchain (mise)
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -205,10 +231,86 @@ jobs:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: make cve-check
 
+  dast:
+    # OWASP ZAP baseline scan against the locally-built image. Runs in parallel
+    # with `docker`. Skipped under act — ZAP's docker-in-docker bind mount of
+    # $GITHUB_WORKSPACE/zap-output does not round-trip through the host Docker
+    # daemon. Run `make dast` directly to cover that ground locally.
+    # `-I` (warn-only) means only FAIL findings block; WARNs are captured in the
+    # uploaded report for review.
+    needs: [changes, build, test]
+    if: ${{ vars.ACT != 'true' && needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build image for scan
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: spring-on-k8s:ci-scan
+          build-args: |
+            JDK_VENDOR=eclipse-temurin
+            JDK_VERSION=21
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        run: make docker-smoke-test
+
+      - name: Cache ZAP image
+        id: cache-zap
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: /tmp/zap-image.tar
+          key: zap-image-${{ env.ZAP_VERSION }}-${{ runner.os }}
+
+      - name: Load cached ZAP image
+        run: |
+          set -euo pipefail
+          if [ -f /tmp/zap-image.tar ]; then
+            echo "Loading ZAP from cache..."
+            docker load -i /tmp/zap-image.tar
+          else
+            echo "Pulling ghcr.io/zaproxy/zaproxy:${ZAP_VERSION}..."
+            docker pull "ghcr.io/zaproxy/zaproxy:${ZAP_VERSION}"
+            docker save "ghcr.io/zaproxy/zaproxy:${ZAP_VERSION}" -o /tmp/zap-image.tar
+          fi
+
+      - name: OWASP ZAP baseline scan
+        run: make dast-scan
+
+      - name: Cleanup smoke container
+        if: always()
+        run: docker rm -f spring-on-k8s-smoke 2>/dev/null || true
+
+      - name: Upload DAST report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: zap-baseline-report
+          path: zap-output/
+          retention-days: 30
+          if-no-files-found: ignore
+
   docker:
-    # Gates 1-3 (build + Trivy + smoke) and Gate 4 build validation run on every push.
+    # Gates 1-3 (build + Trivy + smoke) and Gate 4 amd64 build validation run on every push.
     # Gate 4 push and Gate 5 cosign signing are tag-gated at step level.
-    needs: [static-check, build, test]
+    # Single-arch (linux/amd64) publish — multi-arch is deliberately disabled.
+    # `cve-check` is in `needs:` so a real CVE failure on a tag push blocks the
+    # release. The `if:` uses `!failure() && !cancelled()` so cve-check being
+    # `skipped` on regular pushes (it's tag/schedule/manual-only) does not skip
+    # the docker job.
+    needs: [changes, static-check, build, test, cve-check]
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -221,9 +323,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -261,30 +360,25 @@ jobs:
           image-ref: spring-on-k8s:ci-scan
           format: table
           exit-code: '1'
-          vuln-type: os,library
+          scanners: 'vuln,secret,misconfig'
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           trivyignores: .trivyignore
 
-      # Gate 3: smoke test — readiness endpoint reports UP within 60s.
+      # Gate 3: smoke test — boots image, polls /actuator/health/readiness for UP within 60s.
+      # Implementation lives in `make docker-smoke-test` so the same target runs
+      # locally and in the parallel `dast` job below.
       - name: Smoke test
-        run: |
-          docker run -d --rm --name smoke -p 8080:8080 spring-on-k8s:ci-scan
-          for _ in $(seq 1 30); do
-            if curl -sf http://localhost:8080/actuator/health/readiness | grep -q '"status":"UP"'; then
-              echo "Smoke test PASS: /actuator/health/readiness reports UP"
-              docker stop smoke
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Smoke test FAIL: /actuator/health/readiness did not report UP within 60s"
-          docker logs smoke || true
-          docker stop smoke || true
-          exit 1
+        run: make docker-smoke-test
 
-      # Gate 4: multi-arch build always runs (catches arm64 cross-compile
-      # regressions early); push is tag-gated via step-level conditional.
+      - name: Cleanup smoke container
+        if: always()
+        run: docker rm -f spring-on-k8s-smoke 2>/dev/null || true
+
+      # Gate 4: amd64 build always runs to catch build regressions on the
+      # runner architecture; push is tag-gated via step-level conditional.
+      # Multi-arch (amd64+arm64) is intentionally NOT enabled — single-arch
+      # publish keeps the image index minimal and the build fast.
       - name: Log in to GHCR
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -298,7 +392,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -331,13 +425,14 @@ jobs:
           done <<< "${TAGS}"
 
   ci-pass:
-    # Note: cve-check is intentionally NOT in `needs:`. Transient external-dep
-    # issues (NVD slow responses, Sonatype OSS Index rate limits returning
-    # HTTP 401) should not block a release. cve-check still runs and produces
-    # security signal; failure is visible in the run UI but doesn't gate
-    # ci-pass / branch protection.
+    # Branch-protection / Repository Rulesets aggregator. Lists every upstream
+    # job in `needs:` so a failure or cancellation in any of them blocks the
+    # gate. Skipped jobs (e.g., heavy jobs on doc-only changes via the
+    # `changes` filter; cve-check on non-tag pushes) are treated as PASS —
+    # this is what makes doc-only PRs mergeable while still requiring CI on
+    # code changes.
     if: always()
-    needs: [static-check, build, test, integration-test, e2e, docker]
+    needs: [changes, static-check, build, test, integration-test, e2e, cve-check, dast, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -345,6 +440,10 @@ jobs:
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "One or more upstream jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more upstream jobs were cancelled"
             exit 1
           fi
           echo "All upstream jobs succeeded or were skipped."

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -1,15 +1,16 @@
-name: Cleanup old workflow runs
+name: Cleanup
 
 on:
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   actions: write
 
 jobs:
-  cleanup:
+  cleanup-runs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -25,3 +26,28 @@ jobs:
             --json databaseId,createdAt --limit 200 \
             --jq "${JQ_FILTER}" \
           | xargs -r -I{} gh run delete {} --repo "${{ github.repository }}"
+
+  cleanup-caches:
+    # Stale caches from merged/deleted branches accumulate against the 10 GB
+    # repo limit and silently evict caches the active branches still need.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Delete caches for deleted branches
+        run: |
+          set -euo pipefail
+          # Live refs in the repo (heads + tags), normalised to refs/heads/<name>.
+          LIVE_REFS=$(gh api "repos/${{ github.repository }}/git/refs" --jq '.[].ref' | sort -u)
+          # Every cache, with its ref. gh cache list returns ref like refs/heads/main or refs/pull/N/merge.
+          gh cache list --repo "${{ github.repository }}" --limit 200 --json id,ref --jq '.[] | [.id, .ref] | @tsv' \
+          | while IFS=$'\t' read -r id ref; do
+              # Always preserve caches scoped to live branches/tags.
+              if grep -qx "$ref" <<<"$LIVE_REFS"; then
+                continue
+              fi
+              # PR caches whose source branch was deleted are safe to delete.
+              echo "Deleting cache id=$id ref=$ref"
+              gh cache delete "$id" --repo "${{ github.repository }}" || true
+            done

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ hs_err_pid*
 
 # Claude Code runtime state
 .claude/
+
+# OWASP ZAP DAST output (make dast / dast-scan)
+zap-output/

--- a/.trivyignore
+++ b/.trivyignore
@@ -53,11 +53,11 @@ CVE-2026-34500
 # Upstream Jackson Core via Spring Boot — fixed in 3.1.1; Renovate will PR the bump.
 GHSA-2m67-wjpj-xhg9
 
-# Distroless base image OS packages (gcr.io/distroless/java21-debian12:debug)
+# Distroless base image OS packages (gcr.io/distroless/java21-debian13:nonroot)
 # These are pinned by digest in Dockerfile and tracked by Renovate's dockerfile
 # manager. When the digest bumps, re-evaluate these suppressions — entries that
 # become stale should be removed so new CVEs surface again.
-# Pinned digest as of this suppression: sha256:d100a8c5...
+# Pinned digest as of this suppression: sha256:80b75813...
 CVE-2026-0861    # libc6 (glibc memalign integer overflow, HIGH)
 CVE-2026-25210   # libexpat1 (information disclosure)
 CVE-2026-33416   # libpng16-16 (arbitrary code execution, fix in 1.6.39-2+deb12u4)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Spring Boot 4.0.5 reference service for Kubernetes deployment. Exposes REST endpoints (`/v1/hello`, `/v1/bye`), Swagger UI, Prometheus metrics via Actuator, and K8s liveness / readiness probes. Application configuration is overridden at runtime by a mounted ConfigMap via Spring's `configtree:` property source.
+Spring Boot 4.0.6 reference service for Kubernetes deployment. Exposes REST endpoints (`/v1/hello`, `/v1/bye`), Swagger UI, Prometheus metrics via Actuator, and K8s liveness / readiness probes. Application configuration is overridden at runtime by a mounted ConfigMap via Spring's `configtree:` property source.
 
 ## Build & Run Commands
 
@@ -16,15 +16,14 @@ make e2e                   # Full e2e: kind-up → curl LB assertions → kind-d
 make run                   # Run locally (mvn spring-boot:run) at http://localhost:8080
 make static-check          # Composite quality gate (format-check, lint, secrets, trivy-fs, trivy-config, lint-ci, mermaid-lint, deps-prune-check)
 make mermaid-lint          # Validate Mermaid diagrams in README.md / CLAUDE.md against minlag/mermaid-cli
-make ci                    # Full pipeline: deps → format-check → static-check → test → build
-make ci-run                # Run GitHub Actions workflow locally via act
+make ci                    # Full pipeline: deps → format-check → static-check → test → integration-test → build
+make ci-run                # Run subset of GitHub Actions locally via act (skips e2e, cve-check, ci-pass)
 make image-build           # Build Docker image ($(DOCKER_IMAGE):$(DOCKER_TAG))
 make image-run             # Run Docker container (port 8080)
 make image-stop            # Stop Docker container
 make image-push            # Push Docker image to registry
 make kind-up               # Local K8s: create KinD + cloud-provider-kind + deploy
 make kind-down             # Tear down local K8s
-make e2e                   # Full e2e: kind-up → curl assertions → kind-down
 make upgrade               # Show available Maven dependency updates (dry-run)
 make upgrade-apply         # Apply latest Maven releases (prompts, mutates pom.xml)
 make release VERSION=1.2.3 # Tag a release (with confirmation prompt)
@@ -83,24 +82,24 @@ ytt -f ./k8s | kapp deploy -y --into-ns spring-on-k8s -a spring-on-k8s -f-
 
 K8s manifests in `k8s/`: namespace, deployment (1 replica, 1Gi memory, liveness/readiness probes), LoadBalancer service (80→8080), ConfigMap with `app.message`.
 
-Local e2e path uses KinD + cloud-provider-kind: `make e2e` creates the KinD cluster, runs `cloud-provider-kind` as a host-side Docker container on the `kind` network (it watches `Service: LoadBalancer` resources and assigns IPs from the KinD subnet), deploys, curls the LoadBalancer IP for `/v1/hello` expecting the ConfigMap override message "Hello Kubernetes!", and tears down. Implementation lives in the `kind-setup` Makefile target (one `docker run`) and `scripts/e2e-test.sh`. No separate installer script; the previous MetalLB-based scaffolding (`scripts/kind-metallb-setup.sh`) was removed in favor of this kind-team-maintained approach that works on every supported `kindest/node` version.
+Local e2e path uses KinD + cloud-provider-kind: `make e2e` creates the KinD cluster, runs `cloud-provider-kind` as a host-side Docker container on the `kind` network (it watches `Service: LoadBalancer` resources and assigns IPs from the KinD subnet), deploys, curls the LoadBalancer IP for `/v1/hello` expecting the ConfigMap override message "Hello Kubernetes!", and tears down. Lifecycle decomposes into `kind-create` → `kind-setup` (start cloud-provider-kind) → `kind-load` (load image into KinD) → `kind-deploy` (apply k8s manifests + `kubectl set image` to the actual digest) — orchestrated by `kind-up`; tear down via `kind-down` (alias for `kind-destroy`). The driver is `scripts/e2e-test.sh`. No separate installer script; the previous MetalLB-based scaffolding (`scripts/kind-metallb-setup.sh`) was removed in favor of this kind-team-maintained approach that works on every supported `kindest/node` version.
 
 ## Upgrade Backlog
 
-Items surfaced by `/upgrade-analysis` 2026-04-13. Re-run 2026-04-18:
+Items surfaced by `/upgrade-analysis` 2026-04-13. Re-run 2026-04-27:
 
 - [x] ~~`KIND_VERSION` pinned at non-existent 0.32.0~~ → downgraded to 0.31.0 + `kindest/node:v1.35.0@sha256:452d707d...`
 - [x] ~~google-java-format 1.24.0 → 1.35.0~~ → bumped, GJF jar re-downloaded
-- [x] ~~Maven 3.9.9 → 3.9.14~~ → bumped in Makefile + Dockerfile ARG default (3.9.14 → 3.9.15 pending in PR #201)
+- [x] ~~Maven 3.9.9 → 3.9.15~~ → bumped in `.mise.toml` and Dockerfile `FROM` line
 - [x] ~~metallb → 0.15.3, kubectl → 1.35.3, mermaid-cli → 11.12.0, hadolint → 2.14.0, maven-dependency-plugin → 3.10.0~~ → all bumped
 - [x] ~~Mise migration: 8 CLI tools (act, hadolint, gitleaks, trivy, actionlint, shellcheck, kind, kubectl) moved from Makefile `_VERSION` pins to `.mise.toml`~~ → single source of truth
 - [x] ~~kubectl 1.35.3 → 1.35.4~~ (2026-04-18)
 - [x] ~~Paketo builder 0.4.286 → 0.4.563~~ (`pom.xml`; buildpacks-only path, 277 versions behind)
 - [x] ~~Dockerfile ARG Renovate blind spot~~ → `# renovate:` annotation added to `Dockerfile:1` ARG MVN_VERSION, custom-regex added to `renovate.json`
-- [x] ~~Distroless `java21-debian12:debug` → `java21-debian13:nonroot`~~ (2026-04-18) — ahead of Debian 12 EOL 2026-06-10. Smoke-tested: readiness UP, `/v1/hello` responds, container runs as nonroot:nonroot. Reverted: if troubleshooting via `kubectl exec` is needed, temporarily swap the tag back to `:debug` (keep the same image path / digest pattern).
-- [ ] **Post-release manifest verification (first run after next tag push)** — after the hardened `docker` job first publishes with Pattern A (`provenance: false` + `sbom: false`, multi-arch), run the three checks documented in README §"Post-release manifest verification": (a) `docker buildx imagetools inspect` lists linux/amd64 + linux/arm64 with zero `unknown/unknown` entries, (b) GHCR Packages UI shows the "OS / Arch" tab, (c) `cosign verify` succeeds. Once verified, delete this item.
+- [x] ~~Distroless `java21-debian12:debug` → `java21-debian13:nonroot`~~ (2026-04-18) — ahead of Debian 12 EOL 2026-06-10. Smoke-tested: readiness UP, `/v1/hello` responds, container runs as nonroot:nonroot. To revert temporarily for `kubectl exec` troubleshooting, swap the tag back to `:debug` (keep the same image path / digest pattern).
+- [x] ~~Spring Boot 4.0.5 → 4.0.6~~ (commit `ba27665`). When 4.0.7 ships, re-evaluate the hibernate-validator suppression in `dependency-check-suppressions.xml` (CVE-2025-15104) — drop it if the upstream fix lands.
+- [ ] **Post-release manifest verification (first run after next tag push)** — after the hardened `docker` job first publishes with Pattern A (`provenance: false` + `sbom: false`, single-arch `linux/amd64`), run the three checks in README §"Post-release manifest verification": (a) `docker buildx imagetools inspect` shows `linux/amd64` with zero `unknown/unknown` entries, (b) GHCR Packages UI lists the package, (c) `cosign verify` succeeds. Once verified, delete this item.
 - [ ] **Maven 4.0.0** is at RC-5 (latest: rc-5 published 2025-11-13); GA not yet released. Monitor; migrate when GA ships and plugin ecosystem signals stable 4.x support.
-- [ ] **Spring Boot 4.0.6+** not yet released (latest stable: 4.0.5 published 2026-03-26). When it ships, check hibernate-validator for CVE-2025-15104 fix; remove the corresponding entry from `dependency-check-suppressions.xml` if the upstream fix lands.
 
 ## Skills
 
@@ -122,10 +121,12 @@ When spawning subagents, always pass conventions from the respective skill into 
 - **Docker image:** Multi-stage Dockerfile with distroless runtime (`gcr.io/distroless/java21-debian13:nonroot`, digest-pinned), layered JAR via `spring-boot-maven-plugin`, runs as `nonroot:nonroot` (no shell / no coreutils in runtime). Debian 13 base (Debian 12 EOL 2026-06-10).
 - **Buildpacks alternative:** `mvn spring-boot:build-image` with Paketo builder
 - **CI workflows** (`.github/workflows/`):
-  - `ci.yml` — 8 jobs: `static-check` → { `build`, `test`, `integration-test` } (parallel) → { `e2e` (needs build + test), `docker` (needs all three), `cve-check` (tag/weekly/manual only) } → `ci-pass` (branch-protection gate, `if: always()`). Every job uses `jdx/mise-action` to provision java+maven+CLI tools from `.mise.toml`; `actions/cache` handles `~/.m2/repository` separately. The `docker` job follows Pattern A: Gates 1–3 (build + Trivy image scan blocking CRITICAL/HIGH + smoke test) plus Gate 4 multi-arch build run on every push (catches arm64 cross-compile regressions early); push to GHCR + cosign keyless signing happen only on `v*` tags. `provenance: false` + `sbom: false` keep the image index clean
-  - `cleanup-runs.yml` — weekly (Sunday) run pruning via `gh run delete` (retain 7 days, keep 5 minimum)
-- **Version manager:** [mise](https://mise.jdx.dev/) is the single source of truth for every CLI tool the build needs — Java, Maven, Node, kubectl, kind, act, hadolint, gitleaks, trivy, actionlint, shellcheck all pin in `.mise.toml`. `make deps` bootstraps mise (if missing) and runs `mise install`. The Makefile retains a short list of `_VERSION` constants only for things mise does not manage: `GJF_VERSION` (google-java-format JAR), `DEPCHECK_VERSION` (Maven plugin), `MERMAID_CLI_VERSION` (Docker image), `KIND_NODE_IMAGE` (Docker image digest), `CLOUD_PROVIDER_KIND_VERSION` (Docker image tag on registry.k8s.io)
-- **Renovate:** `renovate.json` drives automated dependency updates. Two `customManagers` regexes track both the `.mise.toml` `# renovate:` inline comments and the remaining Makefile `_VERSION` constants
+  - `ci.yml` — 10 jobs: `changes` (path filter via `dorny/paths-filter`) → `static-check` → { `build`, `test`, `integration-test` } (parallel) → { `e2e` (needs build + test), `dast` (needs build + test), `docker` (needs all three + cve-check), `cve-check` (tag/weekly/manual only) } → `ci-pass` (branch-protection gate, `if: always()`, treats `skipped` as PASS). Path filtering happens **inside** the workflow, not at the trigger level — Repository Rulesets requiring `ci-pass` would deadlock on doc-only changes if `paths-ignore` filtered triggers (no run → no `ci-pass` status). Every code-running job gates on `needs.changes.outputs.code == 'true'`; doc-only PRs skip the heavy jobs and `ci-pass` still goes green. Every job uses `jdx/mise-action` to provision java+maven+CLI tools from `.mise.toml`; `actions/cache` handles `~/.m2/repository` separately. The `docker` job follows Pattern A, single-arch (`linux/amd64`): Gates 1–3 (build + Trivy image scan blocking CRITICAL/HIGH with `scanners=vuln,secret,misconfig` + smoke test via `make docker-smoke-test`) run on every push; Gate 4 publish build + Gate 5 cosign keyless signing happen only on `v*` tags. `provenance: false` + `sbom: false` keep the image index clean. Multi-arch (amd64+arm64) is intentionally disabled — the project ships a single linux/amd64 image. The parallel `dast` job runs OWASP ZAP baseline (`-I` warn-only, only FAIL blocks) against the same locally-built `spring-on-k8s:ci-scan` image; ZAP image is `actions/cache`-d so subsequent runs load in seconds. `dast` is skipped under act (`vars.ACT == 'true'`) — ZAP's docker-in-docker bind mount of `$GITHUB_WORKSPACE/zap-output` does not round-trip through the host Docker daemon; run `make dast` directly for local coverage
+  - `cleanup-runs.yml` (workflow renamed `Cleanup`) — weekly Sunday 00:00 UTC, two jobs: `cleanup-runs` prunes old workflow runs via `gh run delete` (retain 7 days, keep 5 minimum); `cleanup-caches` deletes actions caches scoped to deleted refs (frees room against the 10 GB repo cache limit)
+- **Version manager:** [mise](https://mise.jdx.dev/) is the single source of truth for every CLI tool the build needs — Java, Maven, Node, kubectl, kind, act, hadolint, gitleaks, trivy, actionlint, shellcheck all pin in `.mise.toml`. `make deps` bootstraps mise (if missing) and runs `mise install`. The Makefile retains a short list of `_VERSION` constants only for things mise does not manage: `GJF_VERSION` (google-java-format JAR), `DEPCHECK_VERSION` (Maven plugin), `MERMAID_CLI_VERSION` (Docker image), `KIND_NODE_IMAGE` (Docker image digest), `CLOUD_PROVIDER_KIND_VERSION` (Docker image tag on registry.k8s.io), `ACT_UBUNTU_VERSION` (catthehacker/ubuntu image used by `make ci-run`/`ci-run-tag`), `ZAP_VERSION` (`ghcr.io/zaproxy/zaproxy` Docker image used by `make dast` and the CI `dast` job — also duplicated as a workflow-level `env:` literal in `ci.yml`; both are Renovate-tracked via the workflow `customManagers` regex, so a Renovate PR bumps them together)
+- **Renovate:** `renovate.json` drives automated dependency updates. Enabled managers: `maven`, `github-actions`, `dockerfile`, `kubernetes` (scoped to `k8s/*.ya?ml`), `mise` (native `.mise.toml` reader), and `custom.regex`. Three `customManagers` regexes track inline `# renovate:` comments — one for the Makefile, one for `.mise.toml`, and one for `.github/workflows/*.ya?ml` `env:` literals (covers `ZAP_VERSION` duplicated between the Makefile and the `dast` job)
 - **Trivy suppressions:** `.trivyignore` documents demo-scope K8s hardening exceptions and upstream CVEs tracked by Renovate
+- **`docker` job gates on `cve-check`** via the GitHub idiom `if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' }}`. `cve-check` is in `docker.needs` so a real CVE failure on a tag push blocks the release; on regular pushes `cve-check` is `skipped` (it's tag/schedule/manual-only) and `!failure() && !cancelled()` lets `docker` proceed regardless. `ci-pass` lists both in `needs:` for branch-protection completeness
+- **`k8s/deployment.yml` uses `image: ghcr.io/.../spring-on-k8s:latest`:** intentional template-style placeholder. The actual tag is set at deploy time — `make kind-deploy` runs `kubectl set image deployment/app "app=$(DOCKER_IMAGE):$(DOCKER_TAG)"` after `kubectl apply`, and the Carvel production path uses `ytt` overlays. Renovate's `kubernetes` manager scans the file but treats `:latest` as a no-op (nothing to bump), which is fine
 - **Architecture diagrams:** three inline Mermaid diagrams in README.md (C4 Context under the description, C4 Container + C4 Deployment in the `## Architecture` section). Lint target: `make mermaid-lint` uses the `minlag/mermaid-cli` Docker image (same engine GitHub uses to render). Wired into `make static-check`. No separate PlantUML toolchain — single-service + modest K8s topology fits inside Mermaid C4 cleanly
 - **All `make` targets depend on `deps`** — tool availability is checked / auto-installed before execution

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG JDK_VERSION=21
 # `FROM` line natively (Docker Hub tags for library/maven; bump when the
 # 3.9.x-eclipse-temurin-21 variant is published).
 # https://hub.docker.com/_/maven?tab=tags&page=1&name=eclipse-temurin-21
-FROM maven:3.9.14-eclipse-temurin-21 AS build
+FROM maven:3.9.15-eclipse-temurin-21 AS build
 
 WORKDIR /build
 COPY pom.xml .

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,18 @@ export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)
 # constants below are the exceptions — values that are not mise-managed
 # (Maven plugins, JAR downloads, Docker image pins, literals consumed by
 # Docker build args).
+# JDK_VERSION is the major-only Java version consumed as a Docker `--build-arg`
+# (Dockerfile `ARG JDK_VERSION`). Must stay in sync with `.mise.toml`
+# (`java = "temurin-21"`) and `pom.xml` `<java.version>21</java.version>`.
 JDK_VERSION := 21
-NODE_VERSION := $(shell cat .nvmrc 2>/dev/null || echo 24)
 # renovate: datasource=maven depName=com.google.googlejavaformat:google-java-format
 GJF_VERSION := 1.35.0
 # renovate: datasource=maven depName=org.owasp:dependency-check-maven
 DEPCHECK_VERSION := 12.2.1
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.12.0
+# renovate: datasource=github-releases depName=zaproxy/zaproxy extractVersion=^v(?<version>.*)$$
+ZAP_VERSION := 2.17.0
 # KIND_NODE_IMAGE is tied to the kind release in .mise.toml; each kind
 # release ships a matching node image tag (digest from kind release notes).
 # renovate: datasource=docker depName=kindest/node
@@ -24,9 +28,17 @@ KIND_NODE_IMAGE := kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e0
 # cloud-provider-kind runs as a host-side Docker container on the `kind`
 # network; watches Services of type LoadBalancer and allocates IPs from the
 # KinD Docker subnet. Kind-team maintained (kubernetes-sigs/cloud-provider-kind),
-# works on every supported kindest/node version.
-# renovate: datasource=github-releases depName=kubernetes-sigs/cloud-provider-kind
-CLOUD_PROVIDER_KIND_VERSION := 0.10.0
+# works on every supported kindest/node version. Tracked via the docker
+# datasource so Renovate only proposes versions that are actually published
+# to registry.k8s.io (a github-release without a corresponding image push
+# would be unpullable).
+# renovate: datasource=docker depName=registry.k8s.io/cloud-provider-kind/cloud-controller-manager
+CLOUD_PROVIDER_KIND_VERSION := v0.10.0
+
+# act runner image — pinned so `make ci-run` produces deterministic local
+# CI runs across machines.
+# renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
+ACT_UBUNTU_VERSION := act-24.04
 
 # === Docker image coordinates ===
 APP_NAME        := spring-on-k8s
@@ -80,6 +92,7 @@ deps-gjf:
 #clean: @ Cleanup
 clean: deps
 	@mvn clean
+	@rm -rf zap-output
 
 #build: @ Build project
 build: deps
@@ -113,11 +126,18 @@ format-check: deps-gjf
 	fi; \
 	echo "All Java sources are correctly formatted."
 
-#lint: @ Run Checkstyle + Dockerfile + compiler warning checks
+#lint: @ Run Maven compiler warnings + Checkstyle + hadolint Dockerfile + scripts +x guard
 lint: deps
 	@mvn -B compile
 	@mvn -B checkstyle:check
 	@hadolint Dockerfile
+	@NONEXEC=$$(find scripts -name '*.sh' -not -executable -print 2>/dev/null); \
+	if [ -n "$$NONEXEC" ]; then \
+		echo "ERROR: shell scripts missing executable bit:"; \
+		echo "$$NONEXEC" | sed 's/^/  /'; \
+		echo "Fix with: chmod +x <file>"; \
+		exit 1; \
+	fi
 
 #cve-check: @ OWASP dependency-check vulnerability scan (NVD only)
 # Data source: NVD (requires NVD_API_KEY for fast path — free key from
@@ -141,6 +161,9 @@ cve-check: deps
 	fi; \
 	mvn $$MVN_ARGS
 
+#vulncheck: @ Alias for cve-check (portfolio-standard target name)
+vulncheck: cve-check
+
 #secrets: @ Scan working tree for secrets via gitleaks (CI-oriented; use secrets-history for full git audit)
 secrets: deps
 	@gitleaks detect --source . --no-git --verbose --redact --no-banner
@@ -157,25 +180,33 @@ trivy-fs: deps
 trivy-config: deps
 	@trivy config --exit-code 1 --severity HIGH,CRITICAL --ignorefile .trivyignore k8s/
 
-#lint-ci: @ Lint GitHub Actions workflows (actionlint invokes shellcheck on run: scripts internally)
+#lint-ci: @ Lint GitHub Actions workflows (actionlint + shellcheck via mise)
 lint-ci: deps
 	@actionlint
 	@echo "Workflow lint complete."
 
 #mermaid-lint: @ Validate Mermaid diagrams in markdown files
-mermaid-lint:
-	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for mermaid-lint"; exit 1; }
+mermaid-lint: deps
 	@set -euo pipefail; \
 	MD_FILES=$$(grep -lF '```mermaid' README.md CLAUDE.md 2>/dev/null || true); \
 	if [ -z "$$MD_FILES" ]; then \
 		echo "No Mermaid blocks found — skipping."; \
 		exit 0; \
 	fi; \
+	for attempt in 1 2 3; do \
+		if docker pull --quiet minlag/mermaid-cli:$(MERMAID_CLI_VERSION) >/dev/null 2>&1; then \
+			break; \
+		fi; \
+		[ "$$attempt" -lt 3 ] && { echo "  docker pull attempt $$attempt failed; retrying..."; sleep 2; } || { \
+			echo "ERROR: docker pull minlag/mermaid-cli:$(MERMAID_CLI_VERSION) failed after 3 attempts"; \
+			exit 1; \
+		}; \
+	done; \
 	FAILED=0; \
 	for md in $$MD_FILES; do \
 		echo "Validating Mermaid blocks in $$md..."; \
 		LOG=$$(mktemp); \
-		if docker run --rm -v "$$PWD:/data" \
+		if docker run --rm -v "$$PWD:/data:ro" \
 			minlag/mermaid-cli:$(MERMAID_CLI_VERSION) \
 			-i "/data/$$md" -o "/tmp/$$(basename $$md .md).svg" >"$$LOG" 2>&1; then \
 			echo "  ✓ All blocks rendered cleanly."; \
@@ -217,6 +248,54 @@ upgrade-apply: deps
 image-build: build
 	@docker buildx build --load -t $(DOCKER_IMAGE):$(DOCKER_TAG) --build-arg JDK_VENDOR=eclipse-temurin --build-arg JDK_VERSION=$(JDK_VERSION) .
 
+#docker-smoke-test: @ Boot the locally-built image and verify /actuator/health/readiness reports UP within 60s (leaves container running)
+# Shared by the CI `docker` and `dast` jobs. The caller is responsible for the
+# follow-up `docker rm -f spring-on-k8s-smoke` cleanup step (already wired into
+# both CI jobs as `if: always()` steps; the local `make dast` target runs the
+# cleanup in its own recipe).
+docker-smoke-test:
+	@docker rm -f spring-on-k8s-smoke 2>/dev/null || true
+	@docker run -d --name spring-on-k8s-smoke -p 8080:8080 spring-on-k8s:ci-scan >/dev/null
+	@for _ in $$(seq 1 30); do \
+		if curl -sf http://localhost:8080/actuator/health/readiness 2>/dev/null | grep -q '"status":"UP"'; then \
+			echo "Smoke test PASS: /actuator/health/readiness reports UP"; \
+			exit 0; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "Smoke test FAIL: /actuator/health/readiness did not report UP within 60s"; \
+	docker logs spring-on-k8s-smoke 2>&1 || true; \
+	docker rm -f spring-on-k8s-smoke >/dev/null 2>&1 || true; \
+	exit 1
+
+#dast-scan: @ Run OWASP ZAP baseline against http://localhost:8080 (assumes container is running)
+dast-scan:
+	@mkdir -p zap-output && chmod 777 zap-output
+	@docker run --rm --network host \
+		-v "$$PWD/zap-output:/zap/wrk:rw" \
+		ghcr.io/zaproxy/zaproxy:$(ZAP_VERSION) \
+		zap-baseline.py \
+			-t http://localhost:8080 \
+			-I \
+			-r zap-report.html \
+			-J zap-report.json \
+			-w zap-report.md
+	@echo "DAST report: $$PWD/zap-output/zap-report.html"
+
+#dast: @ Build image, boot, run ZAP baseline DAST scan, cleanup (mirrors CI dast job)
+dast: image-build
+	@docker rm -f spring-on-k8s-test 2>/dev/null || true
+	@docker run -d --name spring-on-k8s-test -p 8080:8080 $(DOCKER_IMAGE):$(DOCKER_TAG) >/dev/null
+	@echo "Waiting for container readiness..."
+	@end=$$(($$(date +%s) + 60)); \
+	while [ $$(date +%s) -lt $$end ]; do \
+		curl -fsS http://localhost:8080/actuator/health/readiness 2>/dev/null | grep -q '"status":"UP"' && break; \
+		sleep 1; \
+	done
+	@$(MAKE) dast-scan ZAP_VERSION=$(ZAP_VERSION) || EXIT=$$?; \
+	docker rm -f spring-on-k8s-test >/dev/null 2>&1 || true; \
+	exit $${EXIT:-0}
+
 #image-run: @ Run Docker container
 image-run: image-stop
 	@docker run --rm -p 8080:8080 --name $(APP_NAME) $(DOCKER_IMAGE):$(DOCKER_TAG)
@@ -236,17 +315,47 @@ image-push: image-build
 ci: deps format-check static-check test integration-test build
 	@echo "CI pipeline completed successfully."
 
-#ci-run: @ Run GitHub Actions workflow locally using act (serialized per-job, random artifact port)
+#ci-run: @ Run a subset of GitHub Actions workflow locally via act (excludes e2e, cve-check, ci-pass)
+# Skipped jobs and rationale:
+#   e2e       — requires KinD inside act (docker-in-docker is flaky); use `make e2e` directly.
+#   cve-check — gated on tags/schedule/manual; requires NVD_API_KEY for fast path.
+#   ci-pass   — meta aggregator; nothing to validate locally.
+# Forwards GH_ACCESS_TOKEN, NVD_API_KEY, OSS_INDEX_USER, OSS_INDEX_TOKEN to act
+# only when set on the host, so the local run mirrors the CI secret surface.
 ci-run: deps
 	@docker container prune -f 2>/dev/null || true
 	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
+	SECRETS=""; \
+	for v in GH_ACCESS_TOKEN NVD_API_KEY OSS_INDEX_USER OSS_INDEX_TOKEN; do \
+		if [ -n "$${!v:-}" ]; then SECRETS="$$SECRETS --secret $$v=$${!v}"; fi; \
+	done; \
 	for j in static-check build test integration-test docker; do \
 		echo "==== act push --job $$j ===="; \
 		act push --job $$j --container-architecture linux/amd64 \
+			-P ubuntu-24.04=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
 			--artifact-server-port "$$ACT_PORT" \
-			--artifact-server-path "$$ARTIFACT_PATH" || exit 1; \
+			--artifact-server-path "$$ARTIFACT_PATH" \
+			$$SECRETS || exit 1; \
 	done
+
+#ci-run-tag: @ Simulate a tag push under act (exercises tag-gated docker job; cosign signing fails — expected, no OIDC under act)
+# The `dast` job is skipped under act (`vars.ACT == 'true'`) — its docker-in-docker
+# bind mount of `$GITHUB_WORKSPACE/zap-output` does not round-trip through the host
+# Docker daemon. Run `make dast` directly to cover that ground locally.
+ci-run-tag: deps
+	@docker container prune -f 2>/dev/null || true
+	@TAG="$$(git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)"; \
+		echo '{"ref":"refs/tags/'"$$TAG"'","ref_type":"tag"}' > /tmp/act-tag-event.json
+	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
+	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
+	act push \
+		--eventpath /tmp/act-tag-event.json \
+		--container-architecture linux/amd64 \
+		-P ubuntu-24.04=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
+		--artifact-server-port "$$ACT_PORT" \
+		--artifact-server-path "$$ARTIFACT_PATH" || true
+	@echo "Note: cosign signing fails under act (no OIDC) — expected. dast job is skipped under act."
 
 #kind-create: @ Create KinD cluster
 kind-create: deps
@@ -263,12 +372,12 @@ kind-setup: kind-create
 	@# allocates IPs from the KinD subnet. No in-cluster install, no IP
 	@# pool to configure. Idempotent: replace any existing container.
 	@docker rm -f cloud-provider-kind >/dev/null 2>&1 || true
-	@echo "Starting cloud-provider-kind v$(CLOUD_PROVIDER_KIND_VERSION)..."
+	@echo "Starting cloud-provider-kind $(CLOUD_PROVIDER_KIND_VERSION)..."
 	@docker run --rm -d \
 		--name cloud-provider-kind \
 		--network kind \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v$(CLOUD_PROVIDER_KIND_VERSION) >/dev/null
+		registry.k8s.io/cloud-provider-kind/cloud-controller-manager:$(CLOUD_PROVIDER_KIND_VERSION) >/dev/null
 
 #kind-load: @ Load the local Docker image into KinD
 kind-load: kind-create image-build
@@ -306,16 +415,18 @@ e2e: kind-up
 	trap '$(MAKE) kind-down' EXIT; \
 	bash scripts/e2e-test.sh
 
-#release: @ Create a release (usage: make release VERSION=1.2.3)
+#release: @ Create and push a release tag (usage: make release VERSION=1.2.3)
 release: deps
 	@if [ -z "$(VERSION)" ]; then echo "Error: VERSION is required (e.g., make release VERSION=1.2.3)"; exit 1; fi
 	@if ! echo "$(VERSION)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then echo "Error: VERSION must be valid semver (e.g., 1.2.3)"; exit 1; fi
-	@bash -c 'read -p "Create release v$(VERSION)? [y/N] " ans && [ "$${ans:-N}" = y ] || { echo "Aborted."; exit 1; }'
+	@bash -c 'read -p "Create AND push release v$(VERSION) (commit + tag → origin)? [y/N] " ans && [ "$${ans:-N}" = y ] || { echo "Aborted."; exit 1; }'
 	@mvn versions:set -DnewVersion=$(VERSION) -DgenerateBackupPoms=false
 	@git add pom.xml
 	@git commit -m "release: v$(VERSION)"
 	@git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
-	@echo "Release v$(VERSION) created. Push with: git push origin main --tags"
+	@git push origin "v$(VERSION)"
+	@git push origin HEAD
+	@echo "Release v$(VERSION) created and pushed."
 
 #renovate-bootstrap: @ Install mise + Node for Renovate
 renovate-bootstrap: deps
@@ -330,8 +441,9 @@ renovate-validate: renovate-bootstrap
 	fi
 
 .PHONY: help deps deps-install deps-check deps-gjf deps-prune deps-prune-check \
-	clean build test integration-test run format format-check lint cve-check \
+	clean build test integration-test run format format-check lint cve-check vulncheck \
 	secrets secrets-history trivy-fs trivy-config lint-ci mermaid-lint \
 	static-check upgrade upgrade-apply image-build image-run image-stop image-push \
+	docker-smoke-test dast dast-scan \
 	kind-create kind-setup kind-load kind-deploy kind-undeploy kind-destroy \
-	kind-up kind-down e2e ci ci-run release renovate-bootstrap renovate-validate
+	kind-up kind-down e2e ci ci-run ci-run-tag release renovate-bootstrap renovate-validate

--- a/README.md
+++ b/README.md
@@ -26,15 +26,18 @@ C4Context
 | Component | Technology |
 |-----------|-----------|
 | Language | Java 21 (source + target + runtime) |
-| Framework | Spring Boot 4.0.5 |
+| Framework | Spring Boot 4.0.6 |
 | API style | REST + OpenAPI via [springdoc-openapi](https://springdoc.org/) 3.0.3 |
 | Metrics | [Micrometer](https://micrometer.io/) + Prometheus registry |
-| Build | Maven 3.9 |
+| Build | Maven 3.9.15 |
 | Container | Multi-stage Dockerfile, distroless runtime, non-root user |
 | Orchestration | Kubernetes 1.30+, deployed via [Carvel](https://carvel.dev/) (`ytt` + `kapp`) |
-| Local K8s | [KinD](https://kind.sigs.k8s.io/) + [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) for `make e2e` |
-| CI/CD | GitHub Actions (split `static-check` / `build` / `test` / `ci-pass`) |
-| Code quality | Checkstyle, hadolint, [google-java-format](https://github.com/google/google-java-format), gitleaks, Trivy, actionlint, OWASP dependency-check |
+| Local K8s | [KinD](https://kind.sigs.k8s.io/) + [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) (test target node image: `kindest/node:v1.35.0`) |
+| CI/CD | GitHub Actions (per-concern jobs; details in [CI/CD section](#cicd)) |
+| Format | [google-java-format](https://github.com/google/google-java-format) |
+| Static analysis | Checkstyle (Java), hadolint (Dockerfile), actionlint (workflows) |
+| Secret scan | gitleaks |
+| Vuln scan | Trivy (filesystem + image + IaC), OWASP dependency-check (NVD) |
 | Dep management | Renovate (automerge minor/patch, 3-day buffer on majors) |
 
 ## Quick Start
@@ -50,16 +53,18 @@ make run           # start at http://localhost:8080
 
 `make deps` installs [mise](https://mise.jdx.dev/) (no root required, to `~/.local/bin`), then runs `mise install` to fetch every pinned tool from `.mise.toml` — Java, Maven, Node, kubectl, kind, act, hadolint, gitleaks, trivy, actionlint, shellcheck. The host only needs the items marked **system** below.
 
-| Tool | Source | Purpose |
-|------|--------|---------|
-| [GNU Make](https://www.gnu.org/software/make/) | **system** | Build orchestration (3.81+) |
-| [Docker](https://www.docker.com/) | **system** | Container image builds, KinD nodes, Mermaid / Trivy containers |
-| [Git](https://git-scm.com/) | **system** | Version control |
-| [mise](https://mise.jdx.dev/) | auto-installed by `make deps` | Manages every tool pinned in `.mise.toml` |
-| Java (Temurin 21), Maven, Node 24 | mise | Build, dependency management, Renovate validation |
-| kubectl, kind | mise | Local K8s cluster for `make e2e` |
-| act, hadolint, gitleaks, trivy, actionlint, shellcheck | mise | Workflow-local CI, linters, security scanners |
-| [Carvel](https://carvel.dev/) | optional | `ytt` + `kapp` for production K8s deploy |
+| Tool | Version | Source | Purpose |
+|------|---------|--------|---------|
+| [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | **system** | Build orchestration |
+| [Docker](https://www.docker.com/) | latest | **system** | Container image builds, KinD nodes, Mermaid / Trivy containers |
+| [Git](https://git-scm.com/) | latest | **system** | Version control |
+| [mise](https://mise.jdx.dev/) | latest | auto-installed by `make deps` | Manages every tool pinned in `.mise.toml` |
+| Java (Temurin) | 21 | mise | Build + runtime |
+| Maven | 3.9.15 | mise | Dependency management |
+| Node | 24 | mise | Renovate validation (`renovate-validate`) |
+| kubectl, kind | pinned in `.mise.toml` | mise | Local K8s cluster for `make e2e` |
+| act, hadolint, gitleaks, trivy, actionlint, shellcheck | pinned in `.mise.toml` | mise | Workflow-local CI, linters, security scanners |
+| [Carvel](https://carvel.dev/) | latest | optional | `ytt` + `kapp` for production K8s deploy |
 
 Install everything:
 
@@ -77,15 +82,17 @@ C4Container
 
   Person(user, "End User")
   System_Ext(prom, "Prometheus")
+  System_Ext(k8s, "Kubernetes", "Probes pod liveness + readiness")
 
   System_Boundary(sys, "spring-on-k8s") {
-    Container(api, "API Service", "Spring Boot 4.0.5, Java 21", "REST controllers + Spring Boot Actuator + springdoc-openapi 3.0.3")
+    Container(api, "API Service", "Spring Boot 4.0.6, Java 21", "REST controllers + Spring Boot Actuator + springdoc-openapi 3.0.3")
     ContainerDb(cm, "ConfigMap", "Kubernetes ConfigMap", "Provides app.message; Spring reads it via configtree mount at /etc/config/")
   }
 
   Rel(user, api, "GET /v1/hello, /v1/bye, /swagger-ui.html", "HTTPS")
   Rel(api, cm, "Reads app.message", "configtree (file mount)")
   Rel(prom, api, "Scrapes /actuator/prometheus", "HTTP")
+  Rel(k8s, api, "Probes /actuator/health/{liveness,readiness}", "HTTP")
 ```
 
 - **API Service** — single Spring Boot process, Micrometer exports Prometheus metrics, Actuator backs the K8s probes (`/actuator/health/liveness`, `/actuator/health/readiness`)
@@ -243,7 +250,7 @@ Run `make help` to see all available targets.
 | `make cve-check` | OWASP dependency-check (fast with `NVD_API_KEY`) |
 | `make deps-prune` | Report unused/undeclared Maven dependencies |
 | `make deps-prune-check` | Fail if unused/undeclared Maven dependencies found |
-| `make static-check` | Composite gate: format-check + lint + secrets + trivy-fs + trivy-config + lint-ci + deps-prune-check |
+| `make static-check` | Composite gate: format-check + lint + secrets + trivy-fs + trivy-config + lint-ci + mermaid-lint + deps-prune-check |
 
 ### Docker
 
@@ -253,6 +260,9 @@ Run `make help` to see all available targets.
 | `make image-run` | Run Docker container |
 | `make image-stop` | Stop Docker container |
 | `make image-push` | Push Docker image to registry |
+| `make docker-smoke-test` | Boot the locally-built `spring-on-k8s:ci-scan` image and verify `/actuator/health/readiness` reports `UP` within 60s (mirrors CI Gate 3) |
+| `make dast` | Build image, boot, run OWASP ZAP baseline scan, cleanup (mirrors CI `dast` job locally) |
+| `make dast-scan` | Run ZAP baseline against `http://localhost:8080` (assumes container is already running) |
 
 ### Kubernetes (KinD)
 
@@ -266,79 +276,113 @@ Run `make help` to see all available targets.
 | `make kind-deploy` | Apply K8s manifests to the KinD cluster (granular) |
 | `make kind-undeploy` | Remove the app from the cluster (granular) |
 | `make kind-destroy` | Delete the KinD cluster (granular) |
-| `make e2e` | Full end-to-end: `kind-up` → curl LB IP assertions → `kind-down` |
+
+> The `make e2e` target lives in the [Testing](#testing-three-layers) group above — it depends on `make kind-up` and tears down via `make kind-down`.
 
 ### CI
 
 | Target | Description |
 |--------|-------------|
-| `make ci` | Full local CI: deps → format-check → static-check → test → build |
-| `make ci-run` | Run the GitHub Actions workflow locally via [act](https://github.com/nektos/act) |
+| `make ci` | Full local CI: deps → format-check → static-check → test → integration-test → build |
+| `make ci-run` | Run a subset of the GitHub Actions workflow locally via [act](https://github.com/nektos/act) — covers `static-check`, `build`, `test`, `integration-test`, `docker`. Skips `e2e` (KinD-in-act flakes), `cve-check` (tag/schedule-gated, slow without `NVD_API_KEY`), and `ci-pass` (meta) |
+| `make ci-run-tag` | Simulate a tag-push event under act (exercises the tag-gated parts of the `docker` job; cosign signing fails — expected, no OIDC under act). The `dast` job is skipped under act — run `make dast` directly to cover that ground |
 
 ### Utilities
 
 | Target | Description |
 |--------|-------------|
 | `make help` | List all available targets |
-| `make deps` | Verify required tools; auto-installs Maven if missing |
-| `make deps-install` | Install Java + Maven via mise (reads `.mise.toml`; one-time bootstrap) |
-| `make deps-check` | Show installed tool versions |
+| `make deps` | Install mise + all tools pinned in `.mise.toml` (idempotent) |
+| `make deps-install` | Alias for `deps` (kept for backwards compatibility) |
+| `make deps-check` | Show installed tool versions from mise |
+| `make deps-gjf` | Download google-java-format JAR (not managed by mise — JAR download only) |
 | `make upgrade` | Show available Maven dependency updates (dry-run) |
 | `make upgrade-apply` | Apply latest Maven releases (prompts, mutates `pom.xml`) |
 | `make release VERSION=x.y.z` | Create a semver release tag |
+| `make renovate-bootstrap` | Install Node via mise so `renovate-validate` can run |
 | `make renovate-validate` | Validate Renovate configuration locally |
 
 ## CI/CD
 
-GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. Non-source paths (`*.md`, `docs/`, images, `LICENSE`) are skipped via `paths-ignore`.
+GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. Path filtering is done **inside** the workflow by a `changes` detector job (using `dorny/paths-filter`), not at the trigger level. Trigger-level `paths-ignore` deadlocks under Repository Rulesets that require a `ci-pass` status check — a doc-only change produces no run, so `ci-pass` reports "expected, not received" indefinitely. With in-workflow filtering, doc-only PRs still create a workflow run; heavy jobs are skipped, and `ci-pass` aggregates the skips into a green status so the merge gate passes.
 
 Every job that needs Java, Maven, or any CLI tool pinned in `.mise.toml` uses `jdx/mise-action` as the single toolchain-provisioning step. `actions/cache` handles the Maven repository (`~/.m2/repository`) separately.
 
+### CI workflow (`.github/workflows/ci.yml`)
+
 | Job | Triggers | Steps |
 |-----|----------|-------|
-| **static-check** | push, PR, tags | `make static-check` (format-check, Checkstyle, hadolint, compiler warnings, gitleaks, Trivy fs + config, actionlint, mermaid-lint, deps-prune-check) |
-| **build** | push, PR, tags (needs: static-check) | `make build` |
-| **test** | push, PR, tags (needs: static-check) | `make test` — unit layer (Surefire) |
-| **integration-test** | push, PR, tags (needs: static-check) | `make integration-test` — in-process integration via Failsafe profile |
-| **e2e** | push, PR, tags (needs: build, test) | `make e2e` — KinD + cloud-provider-kind, asserts ConfigMap override + LB wiring |
-| **cve-check** | tags, weekly Monday 04:00 UTC, manual dispatch (needs: static-check) | `make cve-check` — OWASP dependency-check (fast with `NVD_API_KEY` secret; tag-gated so every release is scanned) |
-| **docker** | every push (needs: static-check, build, test) | Pattern A hardening. Gates 1–3 (single-arch build → Trivy image scan blocking CRITICAL/HIGH → smoke test on `/actuator/health/readiness`) run on every push. Gate 4 (multi-arch build for amd64+arm64) always runs to catch cross-compile regressions; push is tag-gated. Gate 5 (cosign keyless OIDC sign) tag-gated. `provenance: false` + `sbom: false` keep the image index clean so the GHCR "OS / Arch" tab renders |
-| **ci-pass** | always (needs: static-check, build, test, integration-test, e2e, docker) | Single stable branch-protection gate. `cve-check` is intentionally excluded from the gate — transient external-dep issues (Sonatype rate limits, NVD slowness) shouldn't block releases; failures still show in the run UI |
-| **cleanup** | weekly (Sunday) | Prune old workflow runs (retain 7 days, keep 5 minimum) |
+| **changes** | push, PR, tags, schedule, manual | `dorny/paths-filter` — sets `code=true` on any non-doc file change; forced to `true` on tag push, schedule, and `workflow_dispatch` |
+| **static-check** | needs: changes (gated on `code == 'true'`) | `make static-check` (format-check, Checkstyle, hadolint, compiler warnings, gitleaks, Trivy fs + config, actionlint, mermaid-lint, deps-prune-check) |
+| **build** | needs: changes, static-check | `make build` |
+| **test** | needs: changes, static-check | `make test` — unit layer (Surefire) |
+| **integration-test** | needs: changes, static-check | `make integration-test` — in-process integration via Failsafe profile |
+| **e2e** | needs: changes, build, test | `make e2e` — KinD + cloud-provider-kind, asserts ConfigMap override + LB wiring |
+| **cve-check** | tags, weekly Monday 04:00 UTC, manual dispatch (needs: changes, static-check) | `make cve-check` — OWASP dependency-check (fast with `NVD_API_KEY` secret; tag-gated so every release is scanned) |
+| **dast** | every push, parallel with `docker` (needs: changes, build, test) | OWASP ZAP baseline scan against the locally-built image. Builds via `cache-from: type=gha` (~10s cache hit), boots via `make docker-smoke-test`, runs `make dast-scan`. ZAP `-I` mode = warn-only (only FAIL blocks); WARN findings captured in the uploaded `zap-baseline-report` artifact. ZAP image (~3.4 GB) cached via `actions/cache`. Skipped under act (`vars.ACT == 'true'`) — ZAP's docker-in-docker bind mount of `$GITHUB_WORKSPACE/zap-output` does not round-trip through the host Docker daemon |
+| **docker** | every push (needs: changes, static-check, build, test, cve-check) | Pattern A hardening, single-arch (`linux/amd64`). Gates 1–3 (build → Trivy image scan blocking CRITICAL/HIGH with `scanners=vuln,secret,misconfig` → smoke test on `/actuator/health/readiness` via `make docker-smoke-test`) run on every push. Gate 4 (amd64 publish build) tag-gated. Gate 5 (cosign keyless OIDC sign) tag-gated. `provenance: false` + `sbom: false` keep the image index clean. Gates on `cve-check` via `if: !failure() && !cancelled()` so a real CVE on tag push blocks publish, but `cve-check` being `skipped` on regular pushes does not skip docker |
+| **ci-pass** | always (needs: every upstream job including `dast`) | Single stable branch-protection gate. Aggregates `failure` and `cancelled` results across upstream jobs; treats `skipped` as PASS — this is what makes doc-only PRs mergeable without disabling the required check |
+
+### Cleanup workflow (`.github/workflows/cleanup-runs.yml`)
+
+| Job | Triggers | Steps |
+|-----|----------|-------|
+| **cleanup-runs** | weekly (Sunday 00:00 UTC), manual | Prune old workflow runs (retain 7 days, keep 5 minimum) |
+| **cleanup-caches** | weekly (Sunday 00:00 UTC), manual | Delete actions caches scoped to refs that no longer exist (deleted PR branches), reclaiming room against the 10 GB repo cache limit |
+
+### Pre-push image hardening
+
+The `docker` job runs the following gates **before** any image is pushed to GHCR. Any failure blocks the release.
+
+| # | Gate | Catches | Tool |
+|---|------|---------|------|
+| 1 | Build local single-arch image | Build regressions on the runner architecture | `docker/build-push-action` with `load: true` |
+| 2 | **Trivy image scan** (CRITICAL/HIGH blocking, `scanners=vuln,secret,misconfig`) | CVEs in the base image, OS packages, build layers; secrets baked into layers; Dockerfile misconfigs | `aquasecurity/trivy-action` with `image-ref:` |
+| 3 | **Smoke test** | Image boots correctly on its own — Spring Boot reaches `/actuator/health/readiness` UP within 60s | `make docker-smoke-test` |
+| 4 | Build + push (`linux/amd64`) | Publishes the production image to GHCR; push only on `v*` tags | `docker/build-push-action` |
+| 5 | **Cosign keyless OIDC signing** | Sigstore signature on the manifest digest, tag-gated | `sigstore/cosign-installer` + `cosign sign` |
+
+The parallel `dast` job adds one more gate (runs alongside `docker`, separate runner, zero wall-clock cost on the critical path):
+
+| Gate | Catches | Tool |
+|------|---------|------|
+| **OWASP ZAP baseline scan** | Missing security headers, server-info leaks, XSS protection misconfigs, cookie flags | `make dast-scan` ([OWASP ZAP](https://www.zaproxy.org/) `-I` warn-only; report uploaded as `zap-baseline-report` artifact, 30-day retention) |
+
+Buildkit in-manifest attestations (`provenance` + `sbom`) are deliberately disabled (`provenance: false`, `sbom: false`) so the OCI image index stays free of `unknown/unknown` platform entries — that lets the GHCR Packages UI render the "OS / Arch" tab for the multi-arch manifest. Cosign keyless signing still provides the Sigstore signature for supply-chain verification, which is sufficient for almost all consumers.
+
+Verify a published image's signature with:
+
+```bash
+cosign verify ghcr.io/andriykalashnykov/spring-on-k8s:<tag> \
+  --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/spring-on-k8s/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
 
 ### Required Secrets and Variables
 
 | Name | Type | Used by | How to obtain |
 |------|------|---------|---------------|
-| `GITHUB_TOKEN` | Secret (default) | `docker` job (GHCR push), `cleanup` job (run delete) | Provided automatically by GitHub Actions |
+| `GITHUB_TOKEN` | Secret (default) | `docker` job (GHCR push), `cleanup-runs` + `cleanup-caches` jobs (gh CLI) | Provided automatically by GitHub Actions |
 | `NVD_API_KEY` | Secret (recommended) | `cve-check` job (NVD data source) | Free API key from [NIST NVD](https://nvd.nist.gov/developers/request-an-api-key). Without it, NVD uses an anonymous slow path (~15 min); with it, ~1 min |
 
 Set via **Settings → Secrets and variables → Actions → New repository secret**. The same env var works locally (`export NVD_API_KEY=...`) for `make cve-check` runs.
 
 OSS Index (Sonatype) is disabled for this project — Spring Boot's ~173-batch dependency tree exceeds free-tier rate limits even with authentication (server returns HTTP 401, which OWASP dep-check classifies as permanent and does not soft-fail). NVD is the sole CVE data source. If you want OSS Index back, upgrade to a paid Sonatype account and remove the `-DossIndexAnalyzerEnabled=false` flag from `make cve-check`.
 
-### Image signing
-
-On tag push (`v*`), the `docker` job signs the published image with [cosign](https://docs.sigstore.dev/) using keyless OIDC — no signing key to manage. Verify a published image with:
-
-```bash
-cosign verify ghcr.io/andriykalashnykov/spring-on-k8s:<tag> \
-  --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/spring-on-k8s/.*' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-```
-
 ### Post-release manifest verification
 
-After the first `docker` job publishes a multi-arch image, run all three checks before declaring the release good:
+After the first `docker` job publishes the image, run all three checks before declaring the release good:
 
 ```bash
-# 1. Manifest: must list linux/amd64 AND linux/arm64, and ZERO Platform: unknown/unknown entries
+# 1. Manifest: must list linux/amd64 only, with ZERO Platform: unknown/unknown entries
 docker buildx imagetools inspect ghcr.io/andriykalashnykov/spring-on-k8s:<tag>
 
-# 2. GHCR Packages UI: open in a browser — the "OS / Arch" tab must list both architectures
-#    URL: https://github.com/AndriyKalashnykov/spring-on-k8s/pkgs/container/spring-on-k8s
+# 2. GHCR Packages UI: https://github.com/AndriyKalashnykov/spring-on-k8s/pkgs/container/spring-on-k8s
 
-# 3. Cosign signature (command above under "Image signing")
+# 3. Cosign signature (verify command in the Pre-push image hardening section above)
+cosign verify ghcr.io/andriykalashnykov/spring-on-k8s:<tag> \
+  --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/spring-on-k8s/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
 If `imagetools inspect` shows any `Platform: unknown/unknown` entry, buildkit attestations have leaked in — check that `provenance: false` and `sbom: false` are still set on the `Build and push` step of the `docker` job.

--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,15 @@
     "maven",
     "github-actions",
     "dockerfile",
+    "kubernetes",
+    "mise",
     "custom.regex"
   ],
+  "kubernetes": {
+    "managerFilePatterns": [
+      "/^k8s/.+\\.ya?ml$/"
+    ]
+  },
   "vulnerabilityAlerts": {
     "labels": [
       "security"
@@ -85,7 +92,10 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+\\s*:=\\s*(?<currentValue>[^\\s]+)"
-      ]
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{depName}}",
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
     },
     {
       "customType": "regex",
@@ -95,7 +105,23 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ]
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{depName}}",
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update GitHub Actions workflow env literals via inline renovate comments",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\s*\\n\\s+[A-Z_]+:\\s*(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{depName}}",
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
     }
   ]
 }

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -56,11 +56,14 @@ assert_status() {
 }
 
 echo "Running e2e checks..."
+assert_contains /             'Hello world'
 assert_contains /v1/hello "${EXPECTED_MESSAGE}"
 assert_contains /v1/bye   "${EXPECTED_MESSAGE}"
 assert_contains /actuator/health/liveness  '"status":"UP"'
 assert_contains /actuator/health/readiness '"status":"UP"'
 assert_contains /actuator/prometheus       'jvm_memory_used_bytes'
+assert_contains /actuator/prometheus       'http_server_requests_seconds_count'
+assert_contains /v3/api-docs               '/v1/hello'
 assert_status   /does-not-exist-abc 404
 
 echo "All e2e checks passed."

--- a/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
+++ b/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
@@ -60,7 +60,22 @@ public class ApplicationIT {
   public void testHealth() {
     RestClient client = getRestClient();
     String body = client.get().uri("/actuator/health").retrieve().body(String.class);
-    assertThat(body).contains("\"status\":\"UP\"");
+    assertThat(body)
+        .contains("\"status\":\"UP\"")
+        .contains("\"groups\"")
+        .contains("\"liveness\"")
+        .contains("\"readiness\"");
+  }
+
+  @Test
+  public void testSwaggerUi() {
+    RestClient client = getRestClient();
+    var response = client.get().uri("/swagger-ui.html").retrieve().toEntity(String.class);
+    // Springdoc redirects /swagger-ui.html to /swagger-ui/index.html (302) by default.
+    assertThat(
+            response.getStatusCode().is2xxSuccessful()
+                || response.getStatusCode().is3xxRedirection())
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Outcome of `/project-review`, `/harden-image-pipeline`, `/renovate`, `/architecture-diagrams`, and `/claude` skill passes against `main`. Major changes:

- **BLOCKING fix**: replace trigger-level `paths-ignore` with an in-workflow `changes` detector job (`dorny/paths-filter@v3.0.2` SHA-pinned). Repository Rulesets requiring `ci-pass` would deadlock on doc-only PRs otherwise.
- **OWASP ZAP DAST**: new `dast` job parallel to `docker`, cached ZAP image, `-I` warn-only. Local: `make dast`, `make dast-scan`, `make docker-smoke-test`, `make ci-run-tag`.
- **Pattern A image hardening**: Trivy image scan adds `scanners=vuln,secret,misconfig`; `cve-check` gates `docker` via skip-tolerant `if: !failure() && !cancelled()`; single-arch `linux/amd64` publish; cosign keyless OIDC sign on `v*` tag.
- **Cleanup workflow**: rename to `Cleanup`; new `cleanup-caches` job prunes caches scoped to deleted refs.
- **Renovate**: enable `kubernetes` (scoped to `k8s/*.ya?ml`) + native `mise` managers; new third `customManagers` regex for workflow `env:` literals so `ZAP_VERSION` duplicates stay in sync; switch `cloud-provider-kind` annotation to docker datasource.
- **Makefile**: new `ZAP_VERSION` + `ACT_UBUNTU_VERSION` Renovate-pinned; drop dead `NODE_VERSION`; add `vulncheck` alias; mermaid-lint hardening (deps + retry + `:ro`); ci-run secret forwarding + act runner pin; scripts `+x` guard in `lint`; auto-push on `make release`.
- **Tests**: `ApplicationIT.testSwaggerUi` + expanded `testHealth`; `e2e-test.sh` adds `/`, `/v3/api-docs`, and `http_server_requests_seconds_count` assertions.
- **Docs**: README CI/CD section split (CI workflow vs Cleanup workflow); pre-push image hardening gates table; Tech Stack split for scannability; Prerequisites table 4-column. CLAUDE.md spells out 10-job pipeline, 3 `customManagers` regexes, the cve-check skip-tolerant gate, the `:latest` deploy-time override pattern, and the multi-arch-disabled stance.
- **Misc**: Dockerfile maven `3.9.14 → 3.9.15` (matches `.mise.toml`); `.trivyignore` stale `debian12:debug` → `debian13:nonroot`; Container diagram gains K8s probe `Rel`; Spring Boot version drift `4.0.5 → 4.0.6` corrected across README + diagrams.

## Test plan

- [x] `make ci` (deps → format-check → static-check → test → integration-test → build) passes locally
- [x] `make integration-test` — 10 IT tests pass including new `testSwaggerUi` and expanded `testHealth`
- [x] `make mermaid-lint` clean (3 Mermaid blocks parse)
- [x] `actionlint .github/workflows/*.yml` clean
- [x] `npx renovate --platform=local` validates `renovate.json`; discovered deps include the new workflow-tracked `zaproxy/zaproxy`
- [ ] CI run on this PR passes (`changes` → `static-check` → `build`/`test`/`integration-test` → `e2e`/`dast`/`docker` → `ci-pass`)
- [ ] Doc-only follow-up PR passes through `ci-pass` with heavy jobs `skipped` (validates the path-filter fix end-to-end)
- [ ] Tag a release after merge to verify `cve-check` + cosign signing on the `docker` job