### PR TITLE
fix(ci): correct paths-filter pattern on changes job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,26 @@ jobs:
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          predicate-quantifier: 'every'
+          # Default 'some' semantics: `code` = true if ANY changed file matches
+          # the include rules below. Negative patterns prefixed with `!` exclude
+          # doc-only paths from contributing to the match. Native paths-filter
+          # syntax — does not depend on extglob, predicate-quantifier, or other
+          # version-specific features.
           filters: |
             code:
-              - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
+              - '**'
+              - '!**.md'
+              - '!docs/**'
+              - '!specs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.claudeignore'
+              - '!.claude/**'
+              - '!benchmarks/**'
+              - '!**.png'
+              - '!**.jpg'
+              - '!**.gif'
+              - '!**.svg'
               - 'CLAUDE.md'
 
       - name: Combine signal


### PR DESCRIPTION
## Summary

Hotfix: the `changes` detector job introduced in #207 was vacuously passing every PR through `ci-pass`. The buggy filter used an extglob negation (`!(**.md|...)`) and `predicate-quantifier: 'every'` — neither honoured by `dorny/paths-filter`. Net effect: `code=false` on every code-heavy PR → all heavy jobs skipped → `ci-pass` green → automerge fires without actually validating.

Concrete impact: PRs #207, #208, and #209 all auto-merged to main without any of static-check, build, test, integration-test, e2e, dast, or docker actually running.

This PR replaces the buggy pattern with the canonical paths-filter idiom: positive `**` include + explicit `!path` negative excludes, plus a `CLAUDE.md` re-include. No `predicate-quantifier`. No extglob. Defaults to 'some' semantics — `code=true` whenever at least one changed file matches the include set.

## Verification

The signal that this fix works: this PR's heavy jobs (`static-check`, `build`, `test`, `integration-test`, `e2e`, `dast`, `docker`) all RUN and pass — they don't all show as `skipped` like they did on #207.

If `ci-pass` is green AND every upstream job ran (not skipped), the filter is correctly classifying `.github/workflows/ci.yml` as code.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` clean
- [ ] CI on this PR: every gated job RUNS (not skipped)
- [ ] CI on this PR: every gated job passes
- [ ] After merge, a doc-only follow-up PR confirms heavy jobs are correctly `skipped` and `ci-pass` still goes green