### PR TITLE
fix: revert java pin to temurin-21 alias; ignore future bumps

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -10,7 +10,7 @@
 # when 25 LTS ships. Not Renovate-tracked — adoptium-java datasource returns
 # point releases (21.0.10+7.0.LTS) which mise's `temurin-21` alias resolves to
 # automatically. Renovate would churn PRs for every patch with no human value.
-java = "temurin-21.0.11+10.0.LTS"
+java = "temurin-21"
 # renovate: datasource=maven depName=org.apache.maven:apache-maven
 maven = "3.9.15"
 # Node reads from .nvmrc natively.

--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,16 @@
         "docker"
       ],
       "groupName": "Docker dependencies"
+    },
+    {
+      "description": "Don't churn Java patch releases — `.mise.toml` uses the `temurin-21` alias and mise auto-resolves to the latest LTS patch. Pinning to a specific patch (e.g., 21.0.11+10.0.LTS) defeats the alias and produces a Renovate PR for every patch.",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchDepNames": [
+        "java"
+      ],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Revert the `temurin-21` → `temurin-21.0.11+10.0.LTS` pin Renovate auto-merged via #208 (which bypassed CI through the broken paths-filter, now fixed in #212).

The pin contradicts the inline `.mise.toml` comment that explains why we use the alias. Two changes:

1. **`.mise.toml`**: `java = "temurin-21"` — alias resolves to latest LTS patch automatically via mise.
2. **`renovate.json`**: new packageRule with `matchManagers: [mise]` + `matchDepNames: [java]` + `enabled: false`. Renovate ignores `java` bumps; the `temurin-21` alias is preserved long-term. Inline comments are advisory; the packageRule is enforcement.

## Test plan

- [x] `jq . renovate.json` valid
- [x] Local `make ci` clean
- [ ] CI passes — every gated heavy job RUNS (validates the filter fix from #212 holds on this PR)
- [ ] Renovate dashboard no longer lists `java` as an available update after this lands