### PR TITLE
chore: project-review remediation — secret hygiene, test pyramid, drift cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,7 @@ jobs:
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Filter changed paths
-        id: filter
+      - id: filter
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
@@ -75,7 +74,7 @@ jobs:
               - '!**.svg'
               - 'CLAUDE.md'
 
-      - name: Combine signal
+      - name: Compute changes output
         id: combine
         run: |
           if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
@@ -95,8 +94,7 @@ jobs:
         with:
           fetch-depth: 0  # gitleaks needs full git history
 
-      - name: Set up toolchain (mise)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -120,8 +118,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up toolchain (mise)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -145,8 +142,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up toolchain (mise)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -170,8 +166,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up toolchain (mise)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -195,8 +190,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up toolchain (mise)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -208,7 +202,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-m2-
 
-      - name: E2E
+      - name: Run E2E tests
         run: make e2e
 
   cve-check:
@@ -222,8 +216,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up toolchain (mise)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -242,7 +235,7 @@ jobs:
           key: nvd-db-${{ hashFiles('pom.xml') }}
           restore-keys: nvd-db-
 
-      - name: CVE check
+      - name: Run CVE check
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: make cve-check
@@ -452,7 +445,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - name: Check upstream jobs
+      - name: Verify all jobs passed
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "One or more upstream jobs failed"

--- a/Makefile
+++ b/Makefile
@@ -151,15 +151,17 @@ lint: deps
 # OSS_INDEX_USER / OSS_INDEX_TOKEN repo secrets are kept for local dev use
 # and for potential future re-enablement (paid tier or reduced dep tree).
 cve-check: deps
-	@set -e; \
-	MVN_ARGS="-B org.owasp:dependency-check-maven:$(DEPCHECK_VERSION):check -DsuppressionFiles=dependency-check-suppressions.xml -DossindexAnalyzerEnabled=false"; \
-	if [ -n "$$NVD_API_KEY" ]; then \
+	@if [ -n "$$NVD_API_KEY" ]; then \
 		echo "NVD: authenticated (fast path)"; \
-		MVN_ARGS="$$MVN_ARGS -DnvdApiKey=$$NVD_API_KEY"; \
 	else \
 		echo "WARN: NVD_API_KEY not set — NVD slow path may take 10+ min."; \
-	fi; \
-	mvn $$MVN_ARGS
+	fi
+	@# nvdApiKey is read from $$NVD_API_KEY via pom.xml pluginManagement
+	@# (`<nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>`) — keeps the secret out
+	@# of argv. Public flags stay on argv (no leak risk).
+	@mvn -B org.owasp:dependency-check-maven:$(DEPCHECK_VERSION):check \
+		-DsuppressionFiles=dependency-check-suppressions.xml \
+		-DossindexAnalyzerEnabled=false
 
 #vulncheck: @ Alias for cve-check (portfolio-standard target name)
 vulncheck: cve-check
@@ -197,7 +199,7 @@ mermaid-lint: deps
 		if docker pull --quiet minlag/mermaid-cli:$(MERMAID_CLI_VERSION) >/dev/null 2>&1; then \
 			break; \
 		fi; \
-		[ "$$attempt" -lt 3 ] && { echo "  docker pull attempt $$attempt failed; retrying..."; sleep 2; } || { \
+		[ "$$attempt" -lt 3 ] && { echo "  docker pull attempt $$attempt failed; retrying..."; sleep $$((attempt * 5)); } || { \
 			echo "ERROR: docker pull minlag/mermaid-cli:$(MERMAID_CLI_VERSION) failed after 3 attempts"; \
 			exit 1; \
 		}; \
@@ -231,6 +233,9 @@ deps-prune-check: deps
 	@mvn -B dependency:analyze -DignoreNonCompile=true -DfailOnWarning=true
 
 #static-check: @ Fast composite quality gate (format-check, lint, secrets, trivy-fs, trivy-config, lint-ci, mermaid-lint, deps-prune-check)
+# vulncheck/cve-check is intentionally excluded — runs separately as a tag /
+# weekly / manual job in CI. NVD slow path adds 10+ min when NVD_API_KEY is
+# absent, which would dominate every static-check run. See CLAUDE.md.
 static-check: format-check lint secrets trivy-fs trivy-config lint-ci mermaid-lint deps-prune-check
 	@echo "All static checks passed. Run 'make cve-check' separately for vulnerability scan (slow)."
 
@@ -256,6 +261,21 @@ image-build: build
 docker-smoke-test:
 	@docker rm -f spring-on-k8s-smoke 2>/dev/null || true
 	@docker run -d --name spring-on-k8s-smoke -p 8080:8080 spring-on-k8s:ci-scan >/dev/null
+	@# Verify the runtime image exposes the documented port and runs as nonroot.
+	@USER=$$(docker inspect -f '{{.Config.User}}' spring-on-k8s-smoke); \
+	if [ "$$USER" != "nonroot:nonroot" ]; then \
+		echo "Smoke test FAIL: container User='$$USER' (expected 'nonroot:nonroot')"; \
+		docker rm -f spring-on-k8s-smoke >/dev/null 2>&1 || true; \
+		exit 1; \
+	fi; \
+	echo "Image runtime user: $$USER"
+	@PORTS=$$(docker inspect -f '{{range $$p, $$_ := .Config.ExposedPorts}}{{$$p}} {{end}}' spring-on-k8s-smoke); \
+	if ! echo "$$PORTS" | grep -q '8080/tcp'; then \
+		echo "Smoke test FAIL: container ExposedPorts='$$PORTS' (expected to contain 8080/tcp)"; \
+		docker rm -f spring-on-k8s-smoke >/dev/null 2>&1 || true; \
+		exit 1; \
+	fi; \
+	echo "Image exposes: $$PORTS"
 	@for _ in $$(seq 1 30); do \
 		if curl -sf http://localhost:8080/actuator/health/readiness 2>/dev/null | grep -q '"status":"UP"'; then \
 			echo "Smoke test PASS: /actuator/health/readiness reports UP"; \
@@ -292,7 +312,7 @@ dast: image-build
 		curl -fsS http://localhost:8080/actuator/health/readiness 2>/dev/null | grep -q '"status":"UP"' && break; \
 		sleep 1; \
 	done
-	@$(MAKE) dast-scan ZAP_VERSION=$(ZAP_VERSION) || EXIT=$$?; \
+	@$(MAKE) dast-scan || EXIT=$$?; \
 	docker rm -f spring-on-k8s-test >/dev/null 2>&1 || true; \
 	exit $${EXIT:-0}
 
@@ -324,19 +344,25 @@ ci: deps format-check static-check test integration-test build
 # only when set on the host, so the local run mirrors the CI secret surface.
 ci-run: deps
 	@docker container prune -f 2>/dev/null || true
+	@# Synthesize a push event payload that includes `repository.default_branch`
+	@# so the `changes` job's dorny/paths-filter step can resolve its base ref
+	@# (act's default push event omits this, breaking the action with
+	@# "This action requires 'base' input to be configured...").
+	@echo '{"ref":"refs/heads/main","repository":{"default_branch":"main","name":"spring-on-k8s","full_name":"AndriyKalashnykov/spring-on-k8s"}}' > /tmp/act-push-event.json
 	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
-	SECRETS=""; \
+	secret_args=(); \
 	for v in GH_ACCESS_TOKEN NVD_API_KEY OSS_INDEX_USER OSS_INDEX_TOKEN; do \
-		if [ -n "$${!v:-}" ]; then SECRETS="$$SECRETS --secret $$v=$${!v}"; fi; \
+		if [ -n "$${!v:-}" ]; then secret_args+=(--secret "$$v"); fi; \
 	done; \
 	for j in static-check build test integration-test docker; do \
 		echo "==== act push --job $$j ===="; \
 		act push --job $$j --container-architecture linux/amd64 \
+			--eventpath /tmp/act-push-event.json \
 			-P ubuntu-24.04=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
 			--artifact-server-port "$$ACT_PORT" \
 			--artifact-server-path "$$ARTIFACT_PATH" \
-			$$SECRETS || exit 1; \
+			"$${secret_args[@]}" || exit 1; \
 	done
 
 #ci-run-tag: @ Simulate a tag push under act (exercises tag-gated docker job; cosign signing fails — expected, no OIDC under act)
@@ -385,7 +411,10 @@ kind-load: kind-create image-build
 	@kind load docker-image $(DOCKER_IMAGE):$(DOCKER_TAG) --name $(KIND_CLUSTER)
 
 #kind-deploy: @ Apply K8s manifests to the KinD cluster
-kind-deploy: kind-load
+# Depends on kind-setup so the cloud-provider-kind container is running before
+# the LoadBalancer service is created — otherwise the Service hangs in <pending>
+# with no clear failure signal. cloud-provider-kind startup is idempotent.
+kind-deploy: kind-load kind-setup
 	@kubectl apply -f k8s/namespace.yml
 	@kubectl -n spring-on-k8s apply -f k8s/cm.yml -f k8s/deployment.yml -f k8s/service.yml
 	@echo "Patching deployment to use image $(DOCKER_IMAGE):$(DOCKER_TAG)..."

--- a/README.md
+++ b/README.md
@@ -153,21 +153,21 @@ make image-run                                           # run at http://localho
 make image-push                                          # push to registry
 ```
 
-Buildpacks alternative (Paketo). Requires `DOCKER_LOGIN` and `DOCKER_PWD` to be set in your shell first (Docker Hub username + access token):
+Buildpacks alternative (Paketo) — builds the image locally without pushing:
 
 ```bash
 mvn clean spring-boot:build-image \
   -Djava.version=21 \
   -Dimage.publish=false \
-  -Dimage.name="${DOCKER_LOGIN}/spring-on-k8s:latest" \
-  -Ddocker.publishRegistry.username="${DOCKER_LOGIN}" \
-  -Ddocker.publishRegistry.password="${DOCKER_PWD}"
+  -Dimage.name="andriykalashnykov/spring-on-k8s:latest"
 ```
+
+To push, configure registry credentials in `~/.m2/settings.xml` under `<servers>` and run with `-Dimage.publish=true`. Do not pass passwords on the Maven command line — `-D` flag values are visible in `ps -ef` / `/proc/<pid>/cmdline` for the JVM lifetime.
 
 Scan with Docker Scout:
 
 ```bash
-docker scout cves andriykalashnykov/spring-on-k8s:latest
+docker scout cves ghcr.io/andriykalashnykov/spring-on-k8s:latest
 ```
 
 ## Deployment

--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,35 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Spring Boot 4 split the @WebMvcTest slice out of spring-boot-starter-test
+             into its own starter. Required for HelloControllerTest / ByeControllerTest. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${project.artifactId}</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!-- Configuration applies when invoked via direct goal
+                         `mvn org.owasp:dependency-check-maven:VERSION:check`
+                         from `make cve-check`. Reading nvdApiKey from
+                         ${env.NVD_API_KEY} keeps the secret in the process
+                         environment (execve envp) instead of argv, where it
+                         would be visible via `ps -ef` / `/proc/<pid>/cmdline`. -->
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -102,7 +127,15 @@
                         <dep>org.junit.jupiter:*</dep>
                         <dep>org.assertj:*</dep>
                         <dep>io.swagger.core.v3:*</dep>
+                        <!-- ApplicationIT.testOpenApiDocs parses /v3/api-docs JSON via Jackson;
+                             jackson-databind comes transitively through spring-boot-starter-web. -->
+                        <dep>com.fasterxml.jackson.core:jackson-databind</dep>
                     </ignoredUsedUndeclaredDependencies>
+                    <!-- jackson-databind is used in test code only (ApplicationIT) but ships at
+                         compile scope through spring-boot-starter-web. Don't flag the scope mismatch. -->
+                    <ignoredNonTestScopedDependencies>
+                        <dep>com.fasterxml.jackson.core:jackson-databind</dep>
+                    </ignoredNonTestScopedDependencies>
                 </configuration>
             </plugin>
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -55,7 +55,23 @@ assert_status() {
   fi
 }
 
+assert_pod_annotation() {
+  local annotation="$1" expected="$2"
+  local actual
+  actual=$(kubectl -n "${NS}" get deploy "${SVC}" \
+    -o jsonpath="{.spec.template.metadata.annotations.${annotation//./\\.}}" 2>/dev/null || true)
+  if [ "${actual}" = "${expected}" ]; then
+    echo "  PASS  pod annotation ${annotation}=${actual}"
+  else
+    echo "  FAIL  pod annotation ${annotation}=${actual} (expected ${expected})"
+    exit 1
+  fi
+}
+
 echo "Running e2e checks..."
+assert_pod_annotation prometheus.io/scrape "true"
+assert_pod_annotation prometheus.io/path   "/actuator/prometheus"
+assert_pod_annotation prometheus.io/port   "8080"
 assert_contains /             'Hello world'
 assert_contains /v1/hello "${EXPECTED_MESSAGE}"
 assert_contains /v1/bye   "${EXPECTED_MESSAGE}"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,14 +21,7 @@ server:
 spring:
   jmx:
     unique-names: true
-  h2:
-    console:
-      enabled: true
-      path: /console
-      settings:
-        trace: false
-        web-allow-others: false
-        
+
 logging.pattern.console: "%clr(%d{yyyy-MM-dd E HH:mm:ss.SSS}){faint} %clr(%-5p) %clr(${PID}){faint} %clr([%8.15t]){faint} %clr(%c{1}:%L){cyan} %clr(:){red} %clr(%m){faint}%n"
 logging.level.ROOT: "INFO"
 logging.level.org.springframework.: "INFO"

--- a/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
+++ b/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
@@ -18,10 +18,17 @@ package com.vmware.demos.springonk8s;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -30,6 +37,15 @@ public class ApplicationIT {
 
   private RestClient getRestClient() {
     return RestClient.builder().baseUrl("http://localhost:" + port).build();
+  }
+
+  private RestClient noRedirectClient() {
+    HttpClient httpClient =
+        HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build();
+    return RestClient.builder()
+        .baseUrl("http://localhost:" + port)
+        .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+        .build();
   }
 
   @Test
@@ -69,13 +85,13 @@ public class ApplicationIT {
 
   @Test
   public void testSwaggerUi() {
-    RestClient client = getRestClient();
-    var response = client.get().uri("/swagger-ui.html").retrieve().toEntity(String.class);
-    // Springdoc redirects /swagger-ui.html to /swagger-ui/index.html (302) by default.
-    assertThat(
-            response.getStatusCode().is2xxSuccessful()
-                || response.getStatusCode().is3xxRedirection())
-        .isTrue();
+    // Springdoc redirects /swagger-ui.html to /swagger-ui/index.html (302).
+    // Disable redirect-following so the test can pin both the status code and the Location target.
+    var response =
+        noRedirectClient().get().uri("/swagger-ui.html").retrieve().toEntity(String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    String location = response.getHeaders().getFirst(HttpHeaders.LOCATION);
+    assertThat(location).isNotNull().contains("swagger-ui");
   }
 
   @Test
@@ -101,9 +117,74 @@ public class ApplicationIT {
   }
 
   @Test
-  public void testOpenApiDocs() {
+  public void testPrometheusHttpMetrics() {
+    // Prime the MVC instrumentation with one request, then scrape and assert that the
+    // http_server_requests metric appears. Catches regressions where micrometer's web
+    // instrumentation breaks even though jvm_* metrics still publish.
+    RestClient client = getRestClient();
+    client.get().uri("/v1/hello").retrieve().body(String.class);
+    String body = client.get().uri("/actuator/prometheus").retrieve().body(String.class);
+    assertThat(body).contains("http_server_requests_seconds");
+  }
+
+  @Test
+  public void testActuatorInfo() {
+    RestClient client = getRestClient();
+    var response = client.get().uri("/actuator/info").retrieve().toEntity(String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void testHelloProducesTextPlain() {
+    // Controllers declare produces=text/plain; an Accept header that excludes text/plain must
+    // be rejected with 406 (and NOT silently fall through to the catch-all).
+    RestClient client = getRestClient();
+    HttpClientErrorException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            HttpClientErrorException.class,
+            () ->
+                client
+                    .get()
+                    .uri("/v1/hello")
+                    .accept(MediaType.APPLICATION_XML)
+                    .retrieve()
+                    .toBodilessEntity());
+    assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+
+    // text/plain Accept must succeed and return the matching content type.
+    var response =
+        client
+            .get()
+            .uri("/v1/hello")
+            .accept(MediaType.TEXT_PLAIN)
+            .retrieve()
+            .toEntity(String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders().getContentType()).isNotNull();
+    assertThat(response.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_PLAIN))
+        .isTrue();
+  }
+
+  @Test
+  public void testNotFound() {
+    RestClient client = getRestClient();
+    HttpClientErrorException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            HttpClientErrorException.class,
+            () -> client.get().uri("/does-not-exist-abc").retrieve().toBodilessEntity());
+    assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void testOpenApiDocs() throws Exception {
     RestClient client = getRestClient();
     String body = client.get().uri("/v3/api-docs").retrieve().body(String.class);
-    assertThat(body).contains("/v1/hello").contains("/v1/bye");
+    JsonNode root = new ObjectMapper().readTree(body);
+    assertThat(root.path("info").path("title").asText()).isEqualTo("REST + Swagger UI");
+    assertThat(root.path("info").path("version").asText()).isEqualTo("1.0");
+    assertThat(root.path("paths").has("/v1/hello")).isTrue();
+    assertThat(root.path("paths").has("/v1/bye")).isTrue();
+    assertThat(root.path("paths").path("/v1/hello").has("get")).isTrue();
+    assertThat(root.path("paths").path("/v1/bye").has("get")).isTrue();
   }
 }

--- a/src/test/java/com/vmware/demos/springonk8s/AvailabilityIT.java
+++ b/src/test/java/com/vmware/demos/springonk8s/AvailabilityIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.demos.springonk8s;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.availability.ApplicationAvailability;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Asserts that the liveness and readiness probes report independent state. A regression where the
+ * two probe groups collapse onto the same source (or where a readiness flip incorrectly toggles
+ * liveness) would silently break Kubernetes traffic-shedding semantics — the pod would either
+ * accept traffic when it shouldn't or get killed when it should just be drained.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AvailabilityIT {
+
+  @LocalServerPort private int port;
+
+  @Autowired private ApplicationContext context;
+
+  @Autowired private ApplicationAvailability availability;
+
+  private RestClient client() {
+    return RestClient.builder().baseUrl("http://localhost:" + port).build();
+  }
+
+  @Test
+  public void readinessFlipDoesNotAffectLiveness() {
+    AvailabilityChangeEvent.publish(context, ReadinessState.REFUSING_TRAFFIC);
+    try {
+      assertThat(availability.getReadinessState()).isEqualTo(ReadinessState.REFUSING_TRAFFIC);
+      assertThat(availability.getLivenessState()).isEqualTo(LivenessState.CORRECT);
+
+      // /actuator/health/readiness reports OUT_OF_SERVICE → 503.
+      try {
+        client().get().uri("/actuator/health/readiness").retrieve().toBodilessEntity();
+      } catch (HttpServerErrorException.ServiceUnavailable expected) {
+        assertThat(expected.getResponseBodyAsString()).contains("OUT_OF_SERVICE");
+      }
+
+      // Liveness must remain UP — a state flip on readiness is a drain signal, not a kill signal.
+      String liveness =
+          client().get().uri("/actuator/health/liveness").retrieve().body(String.class);
+      assertThat(liveness).contains("\"status\":\"UP\"");
+    } finally {
+      AvailabilityChangeEvent.publish(context, ReadinessState.ACCEPTING_TRAFFIC);
+    }
+  }
+}

--- a/src/test/java/com/vmware/demos/springonk8s/ConfigTreeOverrideIT.java
+++ b/src/test/java/com/vmware/demos/springonk8s/ConfigTreeOverrideIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.demos.springonk8s;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Asserts that values mounted via Spring's {@code configtree:} property source override the
+ * controllers' {@code @Value("${app.message:...}")} defaults — the same mechanism the K8s
+ * deployment uses to inject ConfigMap values at {@code /etc/config/} via {@code
+ * SPRING_CONFIG_IMPORT}.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = "spring.config.import=configtree:target/configtree-test/")
+public class ConfigTreeOverrideIT {
+
+  private static final Path CONFIGTREE_DIR = Path.of("target", "configtree-test");
+  private static final String OVERRIDE = "Hello configtree!";
+
+  @LocalServerPort private int port;
+
+  @BeforeAll
+  static void writeOverride() throws IOException {
+    Files.createDirectories(CONFIGTREE_DIR);
+    Files.writeString(CONFIGTREE_DIR.resolve("app.message"), OVERRIDE);
+  }
+
+  @AfterAll
+  static void cleanup() throws IOException {
+    if (Files.exists(CONFIGTREE_DIR)) {
+      try (var stream = Files.walk(CONFIGTREE_DIR)) {
+        stream.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
+  private RestClient client() {
+    return RestClient.builder().baseUrl("http://localhost:" + port).build();
+  }
+
+  @Test
+  public void helloReflectsConfigtreeOverride() {
+    String body = client().get().uri("/v1/hello").retrieve().body(String.class);
+    assertThat(body).isEqualTo(OVERRIDE);
+  }
+
+  @Test
+  public void byeReflectsConfigtreeOverride() {
+    String body = client().get().uri("/v1/bye").retrieve().body(String.class);
+    assertThat(body).isEqualTo(OVERRIDE);
+  }
+}

--- a/src/test/java/com/vmware/demos/springonk8s/api/rest/controller/ByeControllerTest.java
+++ b/src/test/java/com/vmware/demos/springonk8s/api/rest/controller/ByeControllerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.demos.springonk8s.api.rest.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ByeController.class)
+class ByeControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void byeUsesValueDefaultWhenAppMessageAbsent() throws Exception {
+    mockMvc
+        .perform(get("/v1/bye"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+        .andExpect(content().string("Bye world!"));
+  }
+}

--- a/src/test/java/com/vmware/demos/springonk8s/api/rest/controller/HelloControllerTest.java
+++ b/src/test/java/com/vmware/demos/springonk8s/api/rest/controller/HelloControllerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.demos.springonk8s.api.rest.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HelloController.class)
+class HelloControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void rootReturnsLiteralHelloWorld() throws Exception {
+    mockMvc
+        .perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+        .andExpect(content().string("Hello world"));
+  }
+
+  @Test
+  void greetingUsesValueDefaultWhenAppMessageAbsent() throws Exception {
+    mockMvc
+        .perform(get("/v1/hello"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+        .andExpect(content().string("Hello world!"));
+  }
+}

--- a/src/test/java/com/vmware/demos/springonk8s/api/rest/docs/SwaggerConfigTest.java
+++ b/src/test/java/com/vmware/demos/springonk8s/api/rest/docs/SwaggerConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.demos.springonk8s.api.rest.docs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.Test;
+
+class SwaggerConfigTest {
+
+  @Test
+  void apiBeanExposesConfiguredInfo() {
+    OpenAPI openApi = new SwaggerConfig().api();
+    assertThat(openApi).isNotNull();
+    assertThat(openApi.getInfo()).isNotNull();
+    assertThat(openApi.getInfo().getTitle()).isEqualTo("REST + Swagger UI");
+    assertThat(openApi.getInfo().getDescription()).isEqualTo("REST + Swagger UI sample app");
+    assertThat(openApi.getInfo().getVersion()).isEqualTo("1.0");
+    assertThat(openApi.getInfo().getLicense()).isNotNull();
+    assertThat(openApi.getInfo().getLicense().getName()).isEqualTo("Apache 2.0");
+  }
+}


### PR DESCRIPTION
## Summary

Applies the findings from `/project-review` + `/test-coverage-analysis`:

- **Secret hygiene (HIGH)** — `cve-check` reads `NVD_API_KEY` from env via pom.xml `<pluginManagement>` instead of `-DnvdApiKey=$NVD_API_KEY` on mvn argv; `make ci-run` switches to act `--secret KEY` env-only form (not `--secret KEY=VALUE`). Same class as the documented portfolio incident where tokens leaked via `ps -ef` / `/proc/<pid>/cmdline`.
- **Bug fix** — `kind-deploy` now depends on `kind-setup`, so cloud-provider-kind starts before manifests apply and LoadBalancer Services resolve an external IP.
- **Test pyramid** — built out from 0 unit + 9 integration to 4 unit + 17 integration: `@WebMvcTest` slices for HelloController + ByeController, `SwaggerConfigTest`, `ConfigTreeOverrideIT` (exercises `configtree:/etc/config/` in-process), `AvailabilityIT` (liveness/readiness state-flip independence), plus 5 additions/tightenings to `ApplicationIT` (404, `/actuator/info`, prometheus `http_server_requests`, content-negotiation, strict swagger redirect, OpenAPI JSON parse). Spring Boot 4 split `@WebMvcTest` out of `spring-boot-starter-test` — added `spring-boot-starter-webmvc-test`.
- **CI drift** — drop decorative `Set up toolchain (mise)` name from 6 mise-action steps; rename `E2E`/`CVE check`/`Combine signal`/`Check upstream jobs` to verb-led canonical forms.
- **E2E hardening** — assert `prometheus.io/{scrape,path,port}` annotations on the pod template; `make docker-smoke-test` verifies `Config.User=nonroot:nonroot` and `ExposedPorts` contains `8080/tcp` via `docker inspect`.
- **Cleanup** — remove dead `spring.h2.console.*` (no JPA in project); README buildpacks example no longer teaches argv-flag credentials; `make ci-run` synthesizes a push event with `repository.default_branch` so `dorny/paths-filter` resolves under act.

## Test plan
- [x] `make static-check` — passes
- [x] `make test` — 4 unit tests
- [x] `make integration-test` — 17 ITs
- [x] `make ci` — full pipeline
- [x] `make ci-run` — static-check + build + test + integration-test + docker via act
- [ ] CI on this PR — `ci-pass` reaches green
- [ ] Manual: confirm `kind-deploy` standalone works (LoadBalancer IP resolves)