### PR TITLE
fix(security): finish project-review deferrals; canonical OWASP nvdApiKey via settings.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,6 @@ deps:
 	@command -v docker >/dev/null 2>&1 || { echo "Error: docker is not installed or not in PATH"; exit 1; }
 	@command -v git >/dev/null 2>&1 || { echo "Error: git is not installed or not in PATH"; exit 1; }
 
-#deps-install: @ Alias for deps (kept for backwards compatibility)
-deps-install: deps
-
 #deps-check: @ Show installed tool versions from mise
 deps-check:
 	@command -v mise >/dev/null 2>&1 && mise list || echo "mise not installed — run 'make deps'"
@@ -151,17 +148,27 @@ lint: deps
 # OSS_INDEX_USER / OSS_INDEX_TOKEN repo secrets are kept for local dev use
 # and for potential future re-enablement (paid tier or reduced dep tree).
 cve-check: deps
-	@if [ -n "$$NVD_API_KEY" ]; then \
-		echo "NVD: authenticated (fast path)"; \
-	else \
+	@# Canonical OWASP dependency-check secret pattern (rules/common/security.md):
+	@# write a private settings.xml with <server id="nvd"><password>...</password></server>
+	@# via the bash-builtin printf (no fork → no argv leak), then pass the public
+	@# -DnvdApiServerId=nvd flag. The pom.xml form `${env.NVD_API_KEY}` was avoided
+	@# because `mvn help:effective-pom` would interpolate the live value into stdout.
+	@if [ -z "$$NVD_API_KEY" ]; then \
 		echo "WARN: NVD_API_KEY not set — NVD slow path may take 10+ min."; \
+		mvn -B org.owasp:dependency-check-maven:$(DEPCHECK_VERSION):check \
+			-DsuppressionFiles=dependency-check-suppressions.xml \
+			-DossindexAnalyzerEnabled=false; \
+	else \
+		echo "NVD: authenticated (fast path)"; \
+		SETTINGS=$$(mktemp -t mvn-cve-settings-XXXXXX.xml); \
+		trap 'rm -f "$$SETTINGS"' EXIT; \
+		umask 077; \
+		printf '<settings><servers><server><id>nvd</id><password>%s</password></server></servers></settings>\n' "$$NVD_API_KEY" > "$$SETTINGS"; \
+		mvn -B -s "$$SETTINGS" org.owasp:dependency-check-maven:$(DEPCHECK_VERSION):check \
+			-DsuppressionFiles=dependency-check-suppressions.xml \
+			-DossindexAnalyzerEnabled=false \
+			-DnvdApiServerId=nvd; \
 	fi
-	@# nvdApiKey is read from $$NVD_API_KEY via pom.xml pluginManagement
-	@# (`<nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>`) — keeps the secret out
-	@# of argv. Public flags stay on argv (no leak risk).
-	@mvn -B org.owasp:dependency-check-maven:$(DEPCHECK_VERSION):check \
-		-DsuppressionFiles=dependency-check-suppressions.xml \
-		-DossindexAnalyzerEnabled=false
 
 #vulncheck: @ Alias for cve-check (portfolio-standard target name)
 vulncheck: cve-check
@@ -469,7 +476,7 @@ renovate-validate: renovate-bootstrap
 		npx --yes renovate --platform=local; \
 	fi
 
-.PHONY: help deps deps-install deps-check deps-gjf deps-prune deps-prune-check \
+.PHONY: help deps deps-check deps-gjf deps-prune deps-prune-check \
 	clean build test integration-test run format format-check lint cve-check vulncheck \
 	secrets secrets-history trivy-fs trivy-config lint-ci mermaid-lint \
 	static-check upgrade upgrade-apply image-build image-run image-stop image-push \

--- a/README.md
+++ b/README.md
@@ -293,7 +293,6 @@ Run `make help` to see all available targets.
 |--------|-------------|
 | `make help` | List all available targets |
 | `make deps` | Install mise + all tools pinned in `.mise.toml` (idempotent) |
-| `make deps-install` | Alias for `deps` (kept for backwards compatibility) |
 | `make deps-check` | Show installed tool versions from mise |
 | `make deps-gjf` | Download google-java-format JAR (not managed by mise — JAR download only) |
 | `make upgrade` | Show available Maven dependency updates (dry-run) |

--- a/pom.xml
+++ b/pom.xml
@@ -76,23 +76,6 @@
 
     <build>
         <finalName>${project.artifactId}</finalName>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <!-- Configuration applies when invoked via direct goal
-                         `mvn org.owasp:dependency-check-maven:VERSION:check`
-                         from `make cve-check`. Reading nvdApiKey from
-                         ${env.NVD_API_KEY} keeps the secret in the process
-                         environment (execve envp) instead of argv, where it
-                         would be visible via `ps -ef` / `/proc/<pid>/cmdline`. -->
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <configuration>
-                        <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -130,6 +113,9 @@
                         <!-- ApplicationIT.testOpenApiDocs parses /v3/api-docs JSON via Jackson;
                              jackson-databind comes transitively through spring-boot-starter-web. -->
                         <dep>com.fasterxml.jackson.core:jackson-databind</dep>
+                        <!-- SecurityHeadersFilter implements jakarta.servlet.* types whose embed
+                             jar (tomcat-embed-core) ships transitively via spring-boot-starter-web. -->
+                        <dep>org.apache.tomcat.embed:tomcat-embed-core</dep>
                     </ignoredUsedUndeclaredDependencies>
                     <!-- jackson-databind is used in test code only (ApplicationIT) but ships at
                          compile scope through spring-boot-starter-web. Don't flag the scope mismatch. -->

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -55,6 +55,18 @@ assert_status() {
   fi
 }
 
+assert_header() {
+  local path="$1" header="$2" expected="$3"
+  local actual
+  actual=$(curl -sI --max-time 10 "${BASE_URL}${path}" | grep -i "^${header}:" | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d '\r')
+  if [ "${actual}" = "${expected}" ]; then
+    echo "  PASS  GET ${path}  ${header}: ${actual}"
+  else
+    echo "  FAIL  GET ${path}  ${header}: '${actual}' (expected '${expected}')"
+    exit 1
+  fi
+}
+
 assert_pod_annotation() {
   local annotation="$1" expected="$2"
   local actual
@@ -81,5 +93,7 @@ assert_contains /actuator/prometheus       'jvm_memory_used_bytes'
 assert_contains /actuator/prometheus       'http_server_requests_seconds_count'
 assert_contains /v3/api-docs               '/v1/hello'
 assert_status   /does-not-exist-abc 404
+assert_header   /v1/hello              Cache-Control                 no-store
+assert_header   /v1/hello              Cross-Origin-Resource-Policy  same-origin
 
 echo "All e2e checks passed."

--- a/src/main/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilter.java
+++ b/src/main/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilter.java
@@ -25,16 +25,20 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Sets baseline security response headers on every response. Closes the two ZAP baseline WARN-NEW
- * findings reported by the {@code dast} CI job:
+ * Sets baseline security response headers on every response. Closes ZAP baseline findings reported
+ * by the {@code dast} CI job:
  *
  * <ul>
+ *   <li>{@code 10021 X-Content-Type-Options Header Missing} — sets {@code nosniff} so browsers
+ *       don't MIME-sniff response content.
  *   <li>{@code 10049 Storable and Cacheable Content} — pages must declare a Cache-Control policy.
  *       For an API + actuator + Swagger UI demo, {@code no-store} is appropriate (responses reflect
  *       live state and are cheap to recompute).
  *   <li>{@code 90004 Cross-Origin-Resource-Policy Header Missing or Invalid} — sets {@code
  *       same-origin} so external pages cannot embed our responses.
  * </ul>
+ *
+ * Also sets {@code X-Frame-Options: DENY} as defense-in-depth against clickjacking.
  */
 @Component
 public class SecurityHeadersFilter extends OncePerRequestFilter {
@@ -45,6 +49,8 @@ public class SecurityHeadersFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
     response.setHeader("Cache-Control", "no-store");
     response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    response.setHeader("X-Content-Type-Options", "nosniff");
+    response.setHeader("X-Frame-Options", "DENY");
     chain.doFilter(request, response);
   }
 }

--- a/src/main/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilter.java
+++ b/src/main/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.demos.springonk8s.api.rest.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Sets baseline security response headers on every response. Closes the two ZAP baseline WARN-NEW
+ * findings reported by the {@code dast} CI job:
+ *
+ * <ul>
+ *   <li>{@code 10049 Storable and Cacheable Content} — pages must declare a Cache-Control policy.
+ *       For an API + actuator + Swagger UI demo, {@code no-store} is appropriate (responses reflect
+ *       live state and are cheap to recompute).
+ *   <li>{@code 90004 Cross-Origin-Resource-Policy Header Missing or Invalid} — sets {@code
+ *       same-origin} so external pages cannot embed our responses.
+ * </ul>
+ */
+@Component
+public class SecurityHeadersFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    chain.doFilter(request, response);
+  }
+}

--- a/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
+++ b/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
@@ -166,6 +166,25 @@ public class ApplicationIT {
   }
 
   @Test
+  public void testSecurityHeadersOnApi() {
+    // SecurityHeadersFilter must set Cache-Control: no-store and
+    // Cross-Origin-Resource-Policy: same-origin on every response.
+    var response = getRestClient().get().uri("/v1/hello").retrieve().toEntity(String.class);
+    assertThat(response.getHeaders().getFirst("Cache-Control")).isEqualTo("no-store");
+    assertThat(response.getHeaders().getFirst("Cross-Origin-Resource-Policy"))
+        .isEqualTo("same-origin");
+  }
+
+  @Test
+  public void testSecurityHeadersOnActuator() {
+    // Actuator endpoints get the same headers — ZAP probes /actuator/* too.
+    var response = getRestClient().get().uri("/actuator/health").retrieve().toEntity(String.class);
+    assertThat(response.getHeaders().getFirst("Cache-Control")).isEqualTo("no-store");
+    assertThat(response.getHeaders().getFirst("Cross-Origin-Resource-Policy"))
+        .isEqualTo("same-origin");
+  }
+
+  @Test
   public void testNotFound() {
     RestClient client = getRestClient();
     HttpClientErrorException ex =

--- a/src/test/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilterTest.java
+++ b/src/test/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilterTest.java
@@ -36,5 +36,7 @@ class SecurityHeadersFilterTest {
 
     assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
     assertThat(response.getHeader("Cross-Origin-Resource-Policy")).isEqualTo("same-origin");
+    assertThat(response.getHeader("X-Content-Type-Options")).isEqualTo("nosniff");
+    assertThat(response.getHeader("X-Frame-Options")).isEqualTo("DENY");
   }
 }

--- a/src/test/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilterTest.java
+++ b/src/test/java/com/vmware/demos/springonk8s/api/rest/config/SecurityHeadersFilterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 VMware, Inc. or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.demos.springonk8s.api.rest.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class SecurityHeadersFilterTest {
+
+  @Test
+  void filterSetsCacheControlAndCrossOriginResourcePolicy() throws Exception {
+    SecurityHeadersFilter filter = new SecurityHeadersFilter();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = (req, resp) -> {};
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    assertThat(response.getHeader("Cross-Origin-Resource-Policy")).isEqualTo("same-origin");
+  }
+}


### PR DESCRIPTION
## Summary

- **Security**: migrate `make cve-check` from pom.xml `${env.NVD_API_KEY}` to the canonical settings.xml + `-DnvdApiServerId=nvd` pattern (per `rules/common/security.md`). The pom.xml form kept the value out of mvn argv but `mvn help:effective-pom` would interpolate the live value to stdout — this closes that side-channel. settings.xml is written via bash-builtin `printf` (no fork → no argv leak), mode 0600 in `/tmp`, cleaned via `trap` on EXIT.
- **DAST**: add `SecurityHeadersFilter` (OncePerRequestFilter) setting `Cache-Control: no-store` and `Cross-Origin-Resource-Policy: same-origin` on every response — closes ZAP baseline rules 10049 and 90004 that were warn-only on the prior run.
- **Cleanup**: remove `make deps-install` Makefile alias + matching README row.
- **Tests**: 2 new ApplicationIT methods (security-header assertions on `/v1/hello` + `/actuator/health`), 1 new unit test (`SecurityHeadersFilterTest`); e2e-test.sh asserts both headers on `/v1/hello`.

## Test plan
- [x] `make static-check` — passes
- [x] `make test` — 5 unit tests
- [x] `make integration-test` — 19 ITs
- [x] `make ci` — full pipeline
- [x] `make ci-run` — local act validation
- [x] `make cve-check` — verified `mvn` argv contains only `-DnvdApiServerId=nvd` (public) and `-s <path>` (path); secret is only in printf args (bash builtin) and the mode-0600 file
- [ ] CI on this PR — `ci-pass` reaches green; ZAP DAST report shows `WARN-NEW: 0` for rules 10049 and 90004