### PR TITLE
chore: track Carvel ytt+kapp via mise; drop duplicate .mise.toml regex

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,33 +2,31 @@
 # Run `mise install` to fetch all tools; `mise activate` (shell hook) or the
 # static shim directory on PATH exposes them transparently.
 #
-# Renovate tracks these via inline `# renovate:` comments consumed by the
-# `.mise.toml` custom manager in renovate.json.
+# Renovate tracks every entry below natively via the `mise` manager (enabled in
+# renovate.json). Do NOT add a `custom.regex` over this file — it duplicates
+# the native manager and produces two PRs per bump (see `/renovate` skill,
+# ".mise.toml Renovate custom manager — DO NOT ADD ONE").
 
 [tools]
 # Java: Temurin 21 (LTS). mise picks the latest patch release; bump the major
 # when 25 LTS ships. Not Renovate-tracked — adoptium-java datasource returns
 # point releases (21.0.10+7.0.LTS) which mise's `temurin-21` alias resolves to
 # automatically. Renovate would churn PRs for every patch with no human value.
+# (Renovate suppression configured in renovate.json packageRules.)
 java = "temurin-21"
-# renovate: datasource=maven depName=org.apache.maven:apache-maven
 maven = "3.9.15"
 # Node reads from .nvmrc natively.
 node = "24"
 
-# renovate: datasource=github-releases depName=nektos/act
 act = "0.2.88"
-# renovate: datasource=github-releases depName=hadolint/hadolint
 hadolint = "2.14.0"
-# renovate: datasource=github-releases depName=gitleaks/gitleaks
 gitleaks = "8.30.1"
-# renovate: datasource=github-releases depName=aquasecurity/trivy
 trivy = "0.70.0"
-# renovate: datasource=github-releases depName=rhysd/actionlint
 actionlint = "1.7.12"
-# renovate: datasource=github-releases depName=koalaman/shellcheck
 shellcheck = "0.11.0"
-# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 kind = "0.31.0"
-# renovate: datasource=github-releases depName=kubernetes/kubectl extractVersion=^kubernetes-(?<version>.+)$
 kubectl = "1.36.0"
+
+# Carvel — production K8s deploy path (`ytt -f ./k8s | kapp deploy ...`).
+ytt = "0.54.0"
+kapp = "0.65.2"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make run           # start at http://localhost:8080
 | Node | 24 | mise | Renovate validation (`renovate-validate`) |
 | kubectl, kind | pinned in `.mise.toml` | mise | Local K8s cluster for `make e2e` |
 | act, hadolint, gitleaks, trivy, actionlint, shellcheck | pinned in `.mise.toml` | mise | Workflow-local CI, linters, security scanners |
-| [Carvel](https://carvel.dev/) | latest | optional | `ytt` + `kapp` for production K8s deploy |
+| [ytt](https://carvel.dev/ytt/), [kapp](https://carvel.dev/kapp/) | pinned in `.mise.toml` | mise | Carvel — production K8s deploy (`ytt -f ./k8s \| kapp deploy ...`) |
 
 Install everything:
 

--- a/renovate.json
+++ b/renovate.json
@@ -109,19 +109,6 @@
     },
     {
       "customType": "regex",
-      "description": "Update .mise.toml tool pins via inline renovate comments",
-      "managerFilePatterns": [
-        "/^\\.mise\\.toml$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "{{datasource}}",
-      "depNameTemplate": "{{depName}}",
-      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
-    },
-    {
-      "customType": "regex",
       "description": "Update GitHub Actions workflow env literals via inline renovate comments",
       "managerFilePatterns": [
         "/^\\.github/workflows/.+\\.ya?ml$/"


### PR DESCRIPTION
## Summary

Two changes:

### 1. Carvel toolchain → mise (the user-driven ask)
Adds `ytt = 0.54.0` and `kapp = 0.65.2` to `.mise.toml` so `make deps` installs them alongside every other CLI tool. Promotes the Prerequisites row from "optional" to mise-managed.

Both are in the mise registry as `aqua:carvel-dev/{ytt,kapp}`; the native mise Renovate manager tracks them automatically (github-tags datasource).

### 2. Drop duplicate `.mise.toml` custom-regex manager (`/renovate` finding)
`/renovate` review on the changed file caught a pre-existing duplicate-tracking bug: `renovate.json` ran a `custom.regex` over `.mise.toml` in parallel with the native `mise` manager (which has been in `enabledManagers` for a while). Result: every `.mise.toml` pin was double-tracked, producing two PRs per upstream bump.

The `/renovate` skill is explicit on this — see ".mise.toml Renovate custom manager — DO NOT ADD ONE":

> regex: 15 deps (4 legitimate Makefile + 11 duplicate). Removing the custom manager dropped to `mise: 11 deps, regex: 4 deps`.

Removed the duplicate `customManagers[]` entry and the now-dead `# renovate:` annotations inside `.mise.toml`. Replaced with a header comment explaining the policy so future readers don't re-add the custom manager.

## Validation

| Manager | Before | After | Notes |
|---|---|---|---|
| mise | 13 deps | 13 deps | includes new ytt + kapp |
| regex | 17 deps | 6 deps | -11 duplicate `.mise.toml` matches |
| **total** | **86** | **75** | clean dedup |

- `npx renovate --platform=local`: exit 0, no validationError
- `mise install`: ytt 0.54.0 + kapp 0.65.2 installed; `--version` checks OK
- `.mise.toml` header now warns against re-adding a custom regex

## Test plan
- [ ] CI green (`static-check`, `build`, `test`, `integration-test`, `e2e`, `docker`, `ci-pass`)
- [ ] Renovate's next scan: zero duplicate dependency-dashboard rows for any `.mise.toml` pin