### PR TITLE
test: close all six LOW gaps from /test-coverage-analysis (Phase 4)

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -173,6 +173,45 @@ assert_security_headers() {
   assert_header "${path}" X-Frame-Options               DENY
 }
 
+assert_openapi_paths() {
+  # The OpenAPI JSON at /v3/api-docs must declare both controller paths under
+  # `paths` AND both must have a `get` operation. A substring check would pass
+  # if the path were merely mentioned in a description or example — the structural
+  # check via jq ties the assertion to the real OpenAPI contract.
+  local body
+  body=$(curl -sSf --max-time 10 "${BASE_URL}/v3/api-docs")
+  local has_hello has_bye get_hello get_bye
+  has_hello=$(echo "${body}" | jq -r '.paths | has("/v1/hello")')
+  has_bye=$(echo  "${body}" | jq -r '.paths | has("/v1/bye")')
+  get_hello=$(echo "${body}" | jq -r '.paths."/v1/hello" | has("get")')
+  get_bye=$(echo  "${body}" | jq -r '.paths."/v1/bye"   | has("get")')
+  if [ "${has_hello}" = "true" ] && [ "${has_bye}" = "true" ] \
+     && [ "${get_hello}" = "true" ] && [ "${get_bye}" = "true" ]; then
+    echo "  PASS  /v3/api-docs declares GET /v1/hello and GET /v1/bye"
+  else
+    echo "  FAIL  /v3/api-docs missing path or operation: hasHello=${has_hello} hasBye=${has_bye} getHello=${get_hello} getBye=${get_bye}"
+    exit 1
+  fi
+}
+
+assert_env_on_deployment() {
+  # Confirm an env var is set on the deployed Pod spec. Catches a regression where
+  # a ConfigMap/Secret rewires the env-source but the deploy YAML drops the var
+  # entirely — Spring then falls back to defaults and the ConfigMap override silently
+  # stops applying. Uses jq because kubectl jsonpath has no filter expressions
+  # rich enough to find an env entry by name without falling back to client-side scripting.
+  local name="$1" expected="$2"
+  local actual
+  actual=$("${KUBECTL[@]}" -n "${NS}" get deploy app -o json \
+    | jq -r --arg n "${name}" '.spec.template.spec.containers[0].env[]? | select(.name==$n) | .value // ""')
+  if [ "${actual}" = "${expected}" ]; then
+    echo "  PASS  Deployment.spec env ${name}=${actual}"
+  else
+    echo "  FAIL  Deployment.spec env ${name}='${actual}' (expected '${expected}')"
+    exit 1
+  fi
+}
+
 echo "Running e2e checks..."
 assert_pod_annotation prometheus.io/scrape "true"
 assert_pod_annotation prometheus.io/path   "/actuator/prometheus"
@@ -188,9 +227,11 @@ assert_contains /actuator/health/liveness  '"status":"UP"'
 assert_contains /actuator/health/readiness '"status":"UP"'
 assert_contains /actuator/prometheus       'jvm_memory_used_bytes'
 assert_contains /actuator/prometheus       'http_server_requests_seconds_count'
-assert_contains /v3/api-docs               '/v1/hello'
+assert_openapi_paths
 assert_status   /does-not-exist-abc 404
 assert_security_headers /v1/hello
 assert_security_headers /v1/bye
+assert_security_headers /actuator/health
+assert_env_on_deployment SPRING_CONFIG_IMPORT configtree:/etc/config/
 
 echo "All e2e checks passed."

--- a/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
+++ b/src/test/java/com/vmware/demos/springonk8s/ApplicationIT.java
@@ -133,10 +133,38 @@ public class ApplicationIT {
   }
 
   @Test
-  public void testActuatorInfo() {
+  public void testActuatorInfo() throws Exception {
+    // /actuator/info is exposed (application.yml `include: health,info,prometheus`) and must
+    // return a JSON body. No build-info plugin is wired into pom.xml, so the body is `{}` — but
+    // it must still be a parseable JSON object, not an HTML error page or empty string. A future
+    // contributor enabling the build-info plugin can extend this assertion without rewriting it.
     RestClient client = getRestClient();
     var response = client.get().uri("/actuator/info").retrieve().toEntity(String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders().getContentType()).isNotNull();
+    // Spring Boot Actuator returns a vendor-specific JSON type
+    // (`application/vnd.spring-boot.actuator.v3+json`). Spring's
+    // `MediaType.APPLICATION_JSON.isCompatibleWith(...)` doesn't honor the `+json` structured
+    // suffix here — `application/json` has no suffix and `isCompatibleWith` then short-circuits
+    // false. Check the subtype ends with `json` instead, which captures both `application/json`
+    // and any vendor `+json` variant per RFC 6839.
+    assertThat(response.getHeaders().getContentType().getSubtype()).endsWith("json");
+    JsonNode root = new ObjectMapper().readTree(response.getBody());
+    assertThat(root.isObject()).isTrue();
+  }
+
+  @Test
+  public void testActuatorEnvIsNotExposed() {
+    // Confirm the actuator exposure allowlist (application.yml `include: health,info,prometheus`)
+    // is the real contract: endpoints OUTSIDE that list — e.g., /actuator/env — must 404. If a
+    // future contributor widens the exposure include and forgets the security review, this test
+    // surfaces the change at the IT layer instead of in a ZAP scan against prod.
+    RestClient client = getRestClient();
+    HttpClientErrorException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            HttpClientErrorException.class,
+            () -> client.get().uri("/actuator/env").retrieve().toBodilessEntity());
+    assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
   }
 
   @Test
@@ -164,6 +192,32 @@ public class ApplicationIT {
             .accept(MediaType.TEXT_PLAIN)
             .retrieve()
             .toEntity(String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders().getContentType()).isNotNull();
+    assertThat(response.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_PLAIN))
+        .isTrue();
+  }
+
+  @Test
+  public void testByeProducesTextPlain() {
+    // Symmetric to testHelloProducesTextPlain — guards against a controller-specific MediaType
+    // misconfiguration. ByeController declares `produces=text/plain`; an Accept that excludes it
+    // must 406. If a future change drops the `produces` attribute on /v1/bye, this test fails.
+    RestClient client = getRestClient();
+    HttpClientErrorException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            HttpClientErrorException.class,
+            () ->
+                client
+                    .get()
+                    .uri("/v1/bye")
+                    .accept(MediaType.APPLICATION_XML)
+                    .retrieve()
+                    .toBodilessEntity());
+    assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+
+    var response =
+        client.get().uri("/v1/bye").accept(MediaType.TEXT_PLAIN).retrieve().toEntity(String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getHeaders().getContentType()).isNotNull();
     assertThat(response.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_PLAIN))


### PR DESCRIPTION
## Summary

`/test-coverage-analysis` review (after Phase 0–3 audits cleared all BLOCKING/HIGH skill checks) surfaced six LOW gaps. This PR closes all six — no workarounds, no new infrastructure. Every fix extends an existing target, helper, or test class.

### Integration (`ApplicationIT.java`) — 3 new tests

| # | Test | Gap closed |
|---|---|---|
| 1 | `testActuatorInfo` (extended) | Body shape was unasserted (status-only). Now asserts Content-Type subtype ends with `json` (covers both `application/json` and `application/vnd.spring-boot.actuator.v3+json`) AND body parses as a JSON object |
| 2 | `testActuatorEnvIsNotExposed` (new) | Actuator exposure allowlist (`include: health,info,prometheus`) was a documented contract but not test-locked. A widened `include:` would silently ship endpoints to prod and get caught only by ZAP |
| 3 | `testByeProducesTextPlain` (new) | Mirror of `testHelloProducesTextPlain`. A ByeController-only drop of `produces=text/plain` would have shipped — symmetric assertion closes the gap |

### E2E (`scripts/e2e-test.sh`) — 3 new assertions

| # | Assertion | Gap closed |
|---|---|---|
| 4 | `assert_openapi_paths` | Replaces `assert_contains /v3/api-docs '/v1/hello'` substring check with a jq-based structural check that both `/v1/hello` and `/v1/bye` exist under `paths` AND both declare a `get` operation |
| 5 | `assert_security_headers /actuator/health` | Integration layer already covers this (`testSecurityHeadersOnActuator`); e2e against the deployed pod was missing the parallel assertion |
| 6 | `assert_env_on_deployment SPRING_CONFIG_IMPORT configtree:/etc/config/` | Reads the live Deployment spec via jq. Catches the class of regression where a ConfigMap/Secret rewires the env-source but the deploy YAML drops the var entirely — Spring then falls back to defaults and the ConfigMap override silently stops applying |

### Spring + Spring Boot quirks worth noting

- `MediaType.APPLICATION_JSON.isCompatibleWith(...)` does NOT honor the RFC 6839 `+json` structured suffix when one side has no suffix. For asserting "is JSON in some form" against Spring Boot Actuator's vendor-specific Content-Type, the working check is `getSubtype().endsWith("json")`. Comment in the test documents the trap.

## Validation

- `make integration-test`: **25/25 pass** (3 new + 22 existing)
- `make static-check`: green (format-check + lint + secrets + trivy-fs + trivy-config + lint-ci + mermaid-lint + deps-prune-check)

## Test plan

- [ ] CI: `static-check`, `build`, `test`, `integration-test`, `e2e`, `docker`, `ci-pass` all green
- [ ] E2E specifically exercises the 3 new assertions: `assert_openapi_paths`, `assert_security_headers /actuator/health`, `assert_env_on_deployment SPRING_CONFIG_IMPORT configtree:/etc/config/`