### PR TITLE
fix: silence springdoc 'endpoint is enabled by default' WARNs on startup

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,13 @@ logging.level.com.test.example: "DEBUG"
 logging.level.org.hibernate.SQL: "INFO"
 logging.level.liquibase: "INFO"
 logging.level.org.quartz: "INFO"
+# Silence springdoc-openapi's "endpoint is enabled by default — disable in production" WARNs
+# (org.springdoc.core.events.SpringDocAppInitializer:83 — fires once per startup for /v3/api-docs
+# and once for /swagger-ui.html). This reference service intentionally exposes both endpoints in
+# every environment — that is the documented contract (see README §API). The upstream
+# recommendation to disable in production does not apply; silence the logger rather than ship a
+# false-positive WARN on every startup.
+logging.level.org.springdoc.core.events.SpringDocAppInitializer: "ERROR"
 #logging.file.path: "."
 #logging.file.name: "application.log"
 #logging.pattern.file: "%d{yyyy-MM-dd E HH:mm:ss.SSS} %-5p ${PID} [%8.15t] %c{1}:%L : %m%n"


### PR DESCRIPTION
## Summary

`/ship-it` Stage 5 finding #6 from PR #230's CI log analysis: two `WARN`-level lines from `org.springdoc.core.events.SpringDocAppInitializer` fire on every Spring Boot startup (test + prod), recommending we disable Swagger UI in production.

For this reference service, the README §API documents both `/v3/api-docs` and `/swagger-ui.html` as part of the deliberate public contract — the upstream recommendation doesn't apply. Setting `springdoc.*.enabled=true` explicitly does NOT silence the warning (it fires unconditionally when the endpoints are enabled).

## Real fix

Pin the logger level for the specific springdoc class to `ERROR` in `application.yml` with an inline justification comment.

```yaml
logging.level.org.springdoc.core.events.SpringDocAppInitializer: "ERROR"
```

## Package-path gotcha

Spring's logback default abbreviation is one character per package segment, so the log line shows `o.s.c.e.SpringDocAppInitializer`. The `e` is `events`, NOT `environment` — verified by `unzip -l` on `springdoc-openapi-starter-common.jar`. My first attempt at `org.springdoc.core.environment...` silently failed. Worth flagging because `o.s.c.e.*` is a common abbreviation collision (two springdoc packages: `events` and `environment` both abbreviate the same way).

## Validation

- `make integration-test`: 25/25 pass; **0** `SpringDocAppInitializer` WARN lines (was 6: 2 endpoints × 3 IT classes)
- `make static-check`: green
- `make ci`: green

## Test plan

- [ ] CI green
- [ ] CI logs no longer contain `o.s.c.e.SpringDocAppInitializer:83` lines for this run

Refs #230 (Stage 5 finding #6)