### PR TITLE
chore: renovate.json — 3-day buffer on Carvel tag-before-publish (ytt/kapp)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,18 @@
         "java"
       ],
       "enabled": false
+    },
+    {
+      "description": "Carvel tools — wait 3 days before bumping. The mise `aqua:carvel-dev/*` backend resolves binaries from the GitHub Release page; upstream Carvel pushes the git tag `vX.Y.Z` before its release pipeline publishes the linux-amd64 / darwin-arm64 binary artifacts. Renovate's github-tags datasource sees the tag immediately and opens a PR; `mise install` then 404s on the missing artifacts. Source: spring-on-k8s PR #228 closed 2026-05-11 — kapp 0.65.2 → 0.66.0 PR opened minutes after upstream tag push; CI failed because the v0.66.0 release artifacts hadn't been published yet. Three days is enough buffer for the typical Carvel release pipeline to complete.",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchPackageNames": [
+        "ytt",
+        "kapp",
+        "/^carvel-dev\\//"
+      ],
+      "minimumReleaseAge": "3 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Adds a `minimumReleaseAge: "3 days"` packageRule scoped to mise manager + Carvel deps (ytt/kapp, plus the `/^carvel-dev\\//` prefix for any future additions). Closes the loophole that caused PR #228 to fail.

## Root cause (refresher)

The mise manager uses `github-tags` as the datasource for `aqua:` backends. Some upstream projects — Carvel being the canonical example — push the git tag `vX.Y.Z` minutes before their release pipeline finishes publishing the linux-amd64 / darwin-arm64 binary artifacts. Renovate sees the tag and opens a PR; CI's `mise install` then 404s on the missing release-page artifacts. PR #228 (kapp 0.65.2 → 0.66.0, closed 2026-05-11) was exactly this.

Without this rule, the next Carvel tag push will reproduce the failure (Renovate auto-opens → `static-check` fails → human closes → wait → repeat).

## Why 3 days specifically

Same buffer as the existing major-update packageRule. Reuses the convention; long enough to cover weekend tag pushes; short enough not to delay legitimate fast-track updates.

## Cross-reference

Rule documented in `/renovate` skill under "mise `aqua:` backend can race ahead of upstream release artifacts" (claude-config commit `b0acf76`). This PR is the project-side application of that rule.

## Validation

`make renovate-validate`:
- No `validationError`
- Manager counts unchanged: mise=13, regex=5, total=74

## Test plan

- [ ] CI green on this PR
- [ ] Next Carvel upstream tag push: Renovate does NOT immediately open a PR; waits 3 days; PR opens after artifacts have published; CI green