### PR TITLE
docs(claude): annotate the mvn -Djava.version=21 example as mirroring Makefile JDK_VERSION

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Direct Maven equivalents:
 ```bash
 mvn clean package -DskipTests               # Build
 mvn test                                     # Run all tests
-mvn clean spring-boot:run -Djava.version=21  # Run locally
+mvn clean spring-boot:run -Djava.version=21  # Run locally (the "21" mirrors Makefile's $(JDK_VERSION))
 mvn test -Dtest=ApplicationTests#testHello   # Run single test method
 ```
 


### PR DESCRIPTION
Closes the last outstanding **LOW** finding from `/project-review` — CLAUDE.md's *Direct Maven equivalents* showed `-Djava.version=21` as a bare literal while the Makefile `run:` target parameterizes via `-Djava.version=$(JDK_VERSION)`. Annotate the example so the literal's source is explicit.

Doc-only change — `changes` paths-filter classifies as docs-only; `ci-pass` should pass via skipped heavy jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)