### PR TITLE
chore(deps): complete Spring Boot 4.1.0 GA promotion (drop milestone repo + tomcat override)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -42,16 +42,16 @@ KSV110    # should set metadata.namespace to non-default
 DS-0026
 DS0026
 
-# Upstream Tomcat CVEs bundled via Spring Boot 4.0.5 (tomcat-embed-core 11.0.20).
-# Fixed in Tomcat 11.0.21; Renovate tracks spring-boot-starter-parent and will
-# PR the bump. Suppressing here to keep the signal on NEW findings.
-CVE-2026-34483
-CVE-2026-34486
-CVE-2026-34487
-CVE-2026-34500
-
-# Upstream Jackson Core via Spring Boot — fixed in 3.1.1; Renovate will PR the bump.
-GHSA-2m67-wjpj-xhg9
+# Dependency CVE suppressions: NONE.
+#
+# Spring Boot 4.1.0 GA (pom.xml parent) manages tomcat-embed-* 11.0.22 and
+# Jackson 3.1.4 — past the fixes for the previously-suppressed upstream CVEs
+# (Tomcat CVE-2026-34483/-34486/-34487/-34500, fixed 11.0.21; Jackson
+# GHSA-2m67-wjpj-xhg9, fixed 3.1.1). Those suppressions were removed when the
+# GA bump landed (verified: `trivy fs --severity HIGH,CRITICAL` reports zero
+# findings with no ignorefile). Renovate tracks spring-boot-starter-parent; add
+# a dependency suppression here only for a newly-disclosed CVE awaiting an
+# upstream-fixed release, with a dated rationale.
 
 # Base image OS package suppressions: NONE.
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Spring Boot 4.1.0-RC1 reference service for Kubernetes deployment. Exposes REST endpoints (`/v1/hello`, `/v1/bye`), Swagger UI, Prometheus metrics via Actuator, and K8s liveness / readiness probes. Application configuration is overridden at runtime by a mounted ConfigMap via Spring's `configtree:` property source.
+Spring Boot 4.1.0 reference service for Kubernetes deployment. Exposes REST endpoints (`/v1/hello`, `/v1/bye`), Swagger UI, Prometheus metrics via Actuator, and K8s liveness / readiness probes. Application configuration is overridden at runtime by a mounted ConfigMap via Spring's `configtree:` property source.
 
 ## Build & Run Commands
 
@@ -120,11 +120,11 @@ Local e2e path uses KinD + cloud-provider-kind: `make e2e` creates the KinD clus
 
 ## Upgrade Backlog
 
-Items surfaced by `/upgrade-analysis`; last re-run 2026-05-11.
+Items surfaced by `/upgrade-analysis`; last re-run 2026-06-13.
 
 - [ ] **Maven 4.0.0** is still pre-GA — latest is `4.0.0-rc-5` (published 2026-04-29); GA has no committed date ("will be there when it's there"). Monitor; migrate when GA ships and the plugin ecosystem signals stable 4.x support. Last checked 2026-05-22.
-- [ ] **Spring Boot 4.1.0 GA** — currently pinned to `4.1.0-RC1` (pulled from `https://repo.spring.io/milestone`); promote to GA + remove the Spring milestones repository block from `pom.xml` when GA ships.
-- [ ] **Tomcat CVE override** — `pom.xml` pins `<tomcat.version>11.0.22</tomcat.version>` because the `4.1.0-RC1` BOM manages the CVE-affected 11.0.21. Remove the override once the Spring Boot BOM advances past 11.0.21 (likely with 4.1.0 GA); re-check `make trivy-fs` after removal.
+- [x] **Spring Boot 4.1.0 GA** — done 2026-06-13. Version `4.1.0` GA landed via #250; the Spring milestones `<repositories>`/`<pluginRepositories>` blocks were removed from `pom.xml` (verified: a fresh-local-repo `mvn clean package` resolves every artifact — including Micrometer 1.17.0 GA and Jackson 3.1.4 — from Maven Central with the milestone repo gone).
+- [x] **Tomcat CVE override** — done 2026-06-13. Removed the `<tomcat.version>` override; Spring Boot 4.1.0 GA's BOM now manages tomcat-embed-* `11.0.22` directly (the version the override pinned), so the effective version is unchanged and `trivy fs --severity HIGH,CRITICAL` reports zero findings. The corresponding `.trivyignore` Tomcat/Jackson suppressions were removed in the same change.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ C4Context
 | Component | Technology | Rationale |
 |-----------|-----------|-----------|
 | Language | Java 21 source/target, Java 25 LTS runtime | Project compiles for Java 21 LTS (`pom.xml` `<java.version>21</java.version>`); the published image ships a Java 25 LTS JRE for the longest-supported in-production runtime. Java 21 bytecode runs forward on Java 25 |
-| Framework | Spring Boot 4.1.0-RC1 | Reference target; built-in Actuator covers probes, metrics, and info |
+| Framework | Spring Boot 4.1.0 | Reference target; built-in Actuator covers probes, metrics, and info |
 | API style | REST + OpenAPI via [springdoc-openapi](https://springdoc.org/) 3.0.3 | OpenAPI generated from controller annotations — no separate spec to drift |
 | Metrics | [Micrometer](https://micrometer.io/) + Prometheus registry | Spring Boot default; zero-config Prometheus scrape endpoint |
 | Build | Maven 3.9.15 | Mature Spring Boot tooling; `pom.xml` plays well with Renovate |
@@ -90,7 +90,7 @@ C4Container
   System_Ext(k8s, "Kubernetes", "Probes pod liveness + readiness")
 
   System_Boundary(sys, "spring-on-k8s") {
-    Container(api, "API Service", "Spring Boot 4.1.0-RC1, Java 21", "REST controllers + Spring Boot Actuator + springdoc-openapi 3.0.3")
+    Container(api, "API Service", "Spring Boot 4.1.0, Java 21", "REST controllers + Spring Boot Actuator + springdoc-openapi 3.0.3")
     ContainerDb(cm, "ConfigMap", "Kubernetes ConfigMap", "Provides app.message; Spring reads it via configtree mount at /etc/config/")
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <!-- CVE override: spring-boot-starter-parent 4.1.0-RC1 manages Tomcat 11.0.21,
-             which carries CVE-2026-41293 / -43512 / -43515 (CRITICAL) and
-             CVE-2026-41284 / -42498 / -43513 (HIGH). Pin tomcat-embed-* to 11.0.22
-             (the fixed release). Remove this override once the Spring Boot BOM
-             advances past 11.0.21 — tracked in CLAUDE.md "Upgrade Backlog". -->
-        <tomcat.version>11.0.22</tomcat.version>
-
         <image.publish>false</image.publish>
         <image.name>andriykalashnykov/spring-on-k8s:latest</image.name>
         <image.builder>paketobuildpacks/builder-jammy-base:0.4.563</image.builder>
@@ -34,35 +27,6 @@
         <docker.publishRegistry.password>YOUR-REGISTRY-PASSWORD</docker.publishRegistry.password>
         <docker.publishRegistry.url>docker.io</docker.publishRegistry.url>
     </properties>
-
-    <!--
-        Spring Milestones repository.
-        Required while Spring Boot 4.1.x is pre-GA (RC1 published 2026-04-23).
-        Pulls spring-boot-starter-parent 4.1.0-RC1 + the transitively-managed
-        Micrometer 1.17.0-RC1 and Jackson 3.1.3 from the milestones channel.
-        Remove this block (and revert spring-boot-starter-parent to a Maven
-        Central GA version) once Spring Boot 4.1.0 GA ships.
-    -->
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Spring Boot **4.1.0 GA** landed via #250 (the `spring-boot-starter-parent` version is already `4.1.0`), but the pre-GA scaffolding was left in place. Now that GA and all transitive deps are on Maven Central, this removes it.

## Changes

- **`pom.xml`** — drop the `spring-milestones` `<repositories>`/`<pluginRepositories>` blocks (only needed to bootstrap the pre-GA RC parent) and the `<tomcat.version>11.0.22</tomcat.version>` CVE override. The 4.1.0 GA BOM (`spring-boot-dependencies:4.1.0`) manages `tomcat-embed-*` **11.0.22** directly — the same version the override pinned — so the effective version is unchanged.
- **`.trivyignore`** — remove the now-dead Tomcat (`CVE-2026-34483/-34486/-34487/-34500`, fixed 11.0.21) and Jackson (`GHSA-2m67-wjpj-xhg9`, fixed 3.1.1) suppressions; we ship tomcat 11.0.22 and jackson 3.1.4.
- **`README.md` / `CLAUDE.md`** — `4.1.0-RC1` → `4.1.0`; the two GA-promotion backlog items closed with verification notes.

## Verification

- **Fresh-local-repo build** (`mvn -Dmaven.repo.local=<tmp> clean package`, milestone repo removed) → **BUILD SUCCESS**: every artifact resolves from Maven Central, including Micrometer **1.17.0 GA** and Jackson **3.1.4** (`tools.jackson`). Effective `tomcat.version` = **11.0.22**.
- `make static-check` → **pass** (`trivy fs --severity HIGH,CRITICAL` reports **zero** findings with the slimmed `.trivyignore`; mermaid-lint, format-check, deps-prune-check all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)