### PR TITLE
chore: ship-it sweep — tool upgrades + convention fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,11 +234,19 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-m2-
 
+      # NVD vuln DB is independent of project deps — key on the ISO week, not
+      # pom.xml. Keying on hashFiles('pom.xml') evicts the ~hundreds-of-MB DB on
+      # every dependency bump and forces a cold NVD fetch (~30 min, rate-limit
+      # prone). Weekly rotation keeps the cache warm and still refreshes the DB.
+      - name: Compute NVD cache key (ISO week)
+        id: nvdkey
+        run: echo "week=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache NVD database
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: nvd-db-${{ hashFiles('pom.xml') }}
+          key: nvd-db-${{ steps.nvdkey.outputs.week }}
           restore-keys: nvd-db-
 
       - name: CVE check

--- a/.mise.toml
+++ b/.mise.toml
@@ -14,7 +14,7 @@
 # automatically. Renovate would churn PRs for every patch with no human value.
 # (Renovate suppression configured in renovate.json packageRules.)
 java = "temurin-21"
-maven = "3.9.15"
+maven = "3.9.16"
 # Node reads from .nvmrc natively.
 node = "24"
 
@@ -32,4 +32,4 @@ kubectl = "1.36.2"
 
 # Carvel — production K8s deploy path (`ytt -f ./k8s | kapp deploy ...`).
 ytt = "0.55.1"
-kapp = "0.65.2"
+kapp = "0.65.3"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,9 +122,7 @@ Local e2e path uses KinD + cloud-provider-kind: `make e2e` creates the KinD clus
 
 Items surfaced by `/upgrade-analysis`; last re-run 2026-06-13.
 
-- [ ] **Maven 4.0.0** is still pre-GA — latest is `4.0.0-rc-5` (published 2026-04-29); GA has no committed date ("will be there when it's there"). Monitor; migrate when GA ships and the plugin ecosystem signals stable 4.x support. Last checked 2026-05-22.
-- [x] **Spring Boot 4.1.0 GA** — done 2026-06-13. Version `4.1.0` GA landed via #250; the Spring milestones `<repositories>`/`<pluginRepositories>` blocks were removed from `pom.xml` (verified: a fresh-local-repo `mvn clean package` resolves every artifact — including Micrometer 1.17.0 GA and Jackson 3.1.4 — from Maven Central with the milestone repo gone).
-- [x] **Tomcat CVE override** — done 2026-06-13. Removed the `<tomcat.version>` override; Spring Boot 4.1.0 GA's BOM now manages tomcat-embed-* `11.0.22` directly (the version the override pinned), so the effective version is unchanged and `trivy fs --severity HIGH,CRITICAL` reports zero findings. The corresponding `.trivyignore` Tomcat/Jackson suppressions were removed in the same change.
+- [ ] **Maven 4.0.0** is still pre-GA — latest is `4.0.0-rc-5` (published 2026-04-29); GA has no committed date ("will be there when it's there"). Monitor; migrate when GA ships and the plugin ecosystem signals stable 4.x support. Last checked 2026-06-13.
 
 ## Skills
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG JDK_VERSION=21
 # `FROM` line natively (Docker Hub tags for library/maven; bump when the
 # 3.9.x-eclipse-temurin-21 variant is published).
 # https://hub.docker.com/_/maven?tab=tags&page=1&name=eclipse-temurin-21
-FROM maven:3.9.15-eclipse-temurin-21 AS build
+FROM maven:3.9.16-eclipse-temurin-21 AS build
 
 WORKDIR /build
 COPY pom.xml .

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ZAP_VERSION := 2.17.0
 # Bump manually whenever Renovate bumps `kind` in `.mise.toml` — the value
 # (tag@digest concatenation) is not independently Renovate-trackable per the
 # `/renovate` skill's "Not independently trackable" exception.
-KIND_NODE_IMAGE := kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+KIND_NODE_IMAGE := kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
 # cloud-provider-kind runs as a host-side Docker container on the `kind`
 # network; watches Services of type LoadBalancer and allocates IPs from the
 # KinD Docker subnet. Kind-team maintained (kubernetes-sigs/cloud-provider-kind),
@@ -43,10 +43,13 @@ KIND_NODE_IMAGE := kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e0
 # renovate: datasource=docker depName=registry.k8s.io/cloud-provider-kind/cloud-controller-manager
 CLOUD_PROVIDER_KIND_VERSION := v0.10.0
 
-# act runner image — pinned so `make ci-run` produces deterministic local
-# CI runs across machines.
+# act runner image — pinned to the DATED tag (not the floating `act-24.04`,
+# which catthehacker republishes weekly) so `make ci-run` produces deterministic
+# local CI runs across machines. Renovate rolls the date suffix forward
+# (versioning=loose). The `-P` mapping key MUST be `ubuntu-latest` to match the
+# workflows' `runs-on: ubuntu-latest` (see ci-run / ci-run-tag below).
 # renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
-ACT_UBUNTU_VERSION := act-24.04
+ACT_UBUNTU_VERSION := act-24.04-20260601
 
 # === Docker image coordinates ===
 APP_NAME        := spring-on-k8s
@@ -407,7 +410,7 @@ ci-run: deps
 			--pull=false \
 			--var ACT=true \
 			--eventpath /tmp/act-push-event.json \
-			-P ubuntu-24.04=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
+			-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
 			--artifact-server-port "$$ACT_PORT" \
 			--artifact-server-path "$$ARTIFACT_PATH" \
 			"$${secret_args[@]}" || exit 1; \
@@ -428,7 +431,7 @@ ci-run-tag: deps
 		--container-architecture linux/amd64 \
 		--pull=false \
 		--var ACT=true \
-		-P ubuntu-24.04=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
+		-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
 		--artifact-server-port "$$ACT_PORT" \
 		--artifact-server-path "$$ARTIFACT_PATH" || true
 	@echo "Note: cosign signing fails under act (no OIDC) — expected. dast job is skipped under act."

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ C4Context
 | Framework | Spring Boot 4.1.0 | Reference target; built-in Actuator covers probes, metrics, and info |
 | API style | REST + OpenAPI via [springdoc-openapi](https://springdoc.org/) 3.0.3 | OpenAPI generated from controller annotations — no separate spec to drift |
 | Metrics | [Micrometer](https://micrometer.io/) + Prometheus registry | Spring Boot default; zero-config Prometheus scrape endpoint |
-| Build | Maven 3.9.15 | Mature Spring Boot tooling; `pom.xml` plays well with Renovate |
+| Build | Maven 3.9.16 | Mature Spring Boot tooling; `pom.xml` plays well with Renovate |
 | Container | Multi-stage Dockerfile, `eclipse-temurin:25-jre-alpine` runtime, non-root user (UID/GID 65532) | Adoptium-official Java 25 LTS on Alpine 3.23 — faster CVE turnaround than Google's distroless (rationale and tradeoffs in [`docs/adr/0001-runtime-base-image.md`](docs/adr/0001-runtime-base-image.md)); nonroot UID enables K8s restricted pod security |
 | Orchestration | Kubernetes, deployed via [Carvel](https://carvel.dev/) (`ytt` + `kapp`) | Carvel is GitOps-friendly without the Helm template-hell; `ytt` overlays beat string substitution |
-| Local K8s | [KinD](https://kind.sigs.k8s.io/) + [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) (test target node image: `kindest/node:v1.35.0`) | KinD is what upstream K8s uses for testing; cloud-provider-kind allocates LB IPs without MetalLB's nftables fragility |
+| Local K8s | [KinD](https://kind.sigs.k8s.io/) + [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) (test target node image: `kindest/node:v1.36.1`) | KinD is what upstream K8s uses for testing; cloud-provider-kind allocates LB IPs without MetalLB's nftables fragility |
 | CI/CD | GitHub Actions (per-concern jobs; details in [CI/CD section](#cicd)) | Native to GitHub; SHA-pinned actions; one `ci-pass` aggregator gates the whole pipeline |
 | Format | [google-java-format](https://github.com/google/google-java-format) | Opinionated, deterministic; pairs cleanly with strict `google_checks.xml` Checkstyle (zero violations after format) |
 | Static analysis | Checkstyle (Java), hadolint (Dockerfile), actionlint (workflows) | Each catches a different surface; mermaid-cli on top validates README diagrams |
@@ -65,7 +65,7 @@ make run           # start at http://localhost:8080
 | [Git](https://git-scm.com/) | latest | **system** | Version control |
 | [mise](https://mise.jdx.dev/) | latest | auto-installed by `make deps` | Manages every tool pinned in `.mise.toml` |
 | Java (Temurin) | 21 | mise | Build (compiles for Java 21); the published runtime image uses Java 25 LTS — see Tech Stack |
-| Maven | 3.9.15 | mise | Dependency management |
+| Maven | 3.9.16 | mise | Dependency management |
 | Node | 24 | mise | Renovate validation (`renovate-validate`) |
 | kubectl, kind | pinned in `.mise.toml` | mise | Local K8s cluster for `make e2e` |
 | act, hadolint, gitleaks, trivy, actionlint, shellcheck | pinned in `.mise.toml` | mise | Workflow-local CI, linters, security scanners |
@@ -150,7 +150,7 @@ Sources: diagrams are inline Mermaid in this README — no build step; GitHub re
 
 ## Build & Package
 
-A multi-stage [Dockerfile](./Dockerfile) builds an `eclipse-temurin:25-jre-alpine` runtime image (Java 25 LTS, Alpine 3.23) with a non-root user (UID/GID 65532) and Spring Boot JAR layering. The build stage uses `maven:3.9.15-eclipse-temurin-21` so the artifact compiles for Java 21 LTS bytecode and runs forward on the Java 25 LTS JRE. See [`docs/adr/0001-runtime-base-image.md`](docs/adr/0001-runtime-base-image.md) for the base-image decision (distroless → Alpine, 2026-05-11).
+A multi-stage [Dockerfile](./Dockerfile) builds an `eclipse-temurin:25-jre-alpine` runtime image (Java 25 LTS, Alpine 3.23) with a non-root user (UID/GID 65532) and Spring Boot JAR layering. The build stage uses `maven:3.9.16-eclipse-temurin-21` so the artifact compiles for Java 21 LTS bytecode and runs forward on the Java 25 LTS JRE. See [`docs/adr/0001-runtime-base-image.md`](docs/adr/0001-runtime-base-image.md) for the base-image decision (distroless → Alpine, 2026-05-11).
 
 ```bash
 make image-build                                         # build

--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,19 @@
       "groupName": "Docker dependencies"
     },
     {
+      "description": "Don't pin digests on the Makefile custom.regex docker pins (MERMAID_CLI_VERSION, ZAP_VERSION, etc.). `config:best-practices` enables `docker:pinDigests`, which generates a pinDigest update for these tag-only pins; that pinDigest collides with the version bump on the shared `renovate/docker-dependencies` branch and Renovate's collision-dedup silently DROPS the version bump (e.g. minlag/mermaid-cli froze at 11.14.0 while 11.15.0 was suppressed). These are bare `IMAGE:TAG` literals consumed by `docker run`/`docker pull`; a tag bump is the intended update, not a digest pin.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "Makefile"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false
+    },
+    {
       "description": "Don't churn Java patch releases — `.mise.toml` uses the `temurin-21` alias and mise auto-resolves to the latest LTS patch. Pinning to a specific patch (e.g., 21.0.11+10.0.LTS) defeats the alias and produces a Renovate PR for every patch.",
       "matchManagers": [
         "mise"
@@ -93,14 +106,9 @@
       "enabled": false
     },
     {
-      "description": "Carvel tools — wait 3 days before bumping. The mise `aqua:carvel-dev/*` backend resolves binaries from the GitHub Release page; upstream Carvel pushes the git tag `vX.Y.Z` before its release pipeline publishes the linux-amd64 / darwin-arm64 binary artifacts. Renovate's github-tags datasource sees the tag immediately and opens a PR; `mise install` then 404s on the missing artifacts. Source: spring-on-k8s PR #228 closed 2026-05-11 — kapp 0.65.2 → 0.66.0 PR opened minutes after upstream tag push; CI failed because the v0.66.0 release artifacts hadn't been published yet. Three days is enough buffer for the typical Carvel release pipeline to complete.",
+      "description": "Manager-wide 3-day buffer on every mise-managed tool (NOT a package allowlist). The mise backends resolve binaries from GitHub Releases; upstream projects push the git tag `vX.Y.Z` before their release pipeline publishes the linux-amd64 / darwin-arm64 artifacts. Renovate's github-tags/releases datasource sees the tag immediately and opens a PR; `mise install` then 404s on the missing artifacts. The original Carvel-only allowlist (ytt/kapp) protected only known offenders — the next tag-before-publish tool (maven, kind, trivy, …) would 404 first. A manager-wide buffer covers all of them. Source: spring-on-k8s PR #228 closed 2026-05-11 — kapp 0.65.2 → 0.66.0 PR opened minutes after upstream tag push; `mise install` failed because the v0.66.0 artifacts had not yet published. Three days is enough buffer for a typical release pipeline. (Java is exempt above via the `temurin-21` alias rule.)",
       "matchManagers": [
         "mise"
-      ],
-      "matchPackageNames": [
-        "ytt",
-        "kapp",
-        "/^carvel-dev\\//"
       ],
       "minimumReleaseAge": "3 days"
     }


### PR DESCRIPTION
Full `/ship-it` health pass: upgrade pinned tools, review all infra against conventions on the upgraded state, apply fixes, verify locally.

## Stage 1 — Upgrades (verified)
| Item | Change | Verification |
|------|--------|--------------|
| `.mise.toml` maven | 3.9.15 → **3.9.16** | `make deps` + `mvn -v` |
| `.mise.toml` kapp | 0.65.2 → **0.65.3** | `make deps` + `kapp version` |
| Dockerfile build maven | 3.9.15 → **3.9.16** | image rebuild (digest d7e7f574), structure + smoke tests |
| `KIND_NODE_IMAGE` | kindest/node **v1.35.0 → v1.36.1** (kind 0.32.0 default; digest from kind v0.32.0 release notes) | **`make e2e` — all assertions pass on v1.36.1** |

`minlag/mermaid-cli 11.15.0` deferred — Renovate is now unblocked to PR it (see the `pinDigests:false` fix below). Its Docker tag wasn't pullable at sweep time anyway.

## Stage 2 — Convention fixes (verified)
- **Makefile (HIGH)** — `act -P` mapping key `ubuntu-24.04` → `ubuntu-latest`. Every workflow job is `runs-on: ubuntu-latest`, so the pinned catthehacker image was **silently inert** under `make ci-run` (act used its default image).
- **Makefile (MEDIUM)** — pin `ACT_UBUNTU_VERSION` to the dated `act-24.04-20260601` (the floating `act-24.04` is republished weekly → non-deterministic local CI, contradicting the "deterministic" comment).
- **renovate.json (HIGH)** — add scoped `pinDigests:false` for the Makefile `custom.regex` docker pins. `config:best-practices`→`docker:pinDigests` was colliding with the version bump on the shared branch and **silently dropping it** (confirmed via `npx renovate --platform=local`: mermaid-cli frozen at 11.14.0, 11.15.0 suppressed).
- **renovate.json (MEDIUM)** — replace the Carvel-only `minimumReleaseAge` allowlist with a **manager-wide** 3-day buffer on the `mise` manager (covers maven/kapp/kind/trivy/…, not just ytt/kapp) — the durable fix for the tag-before-publish 404 race (PR #228 class).
- **ci.yml (MEDIUM)** — key the NVD-DB cache on the ISO week, not `hashFiles('pom.xml')` (the vuln DB is independent of deps; a pom bump was evicting it → cold ~30-min NVD fetch).
- **README.md / CLAUDE.md** — version-cell drift (Maven 3.9.16, kindest/node v1.36.1) + backlog hygiene.

### Verified-false-positives (NOT applied, with reason)
- *cve-check missing OSS Index credentials* — OSS Index is **intentionally disabled** (`-DossindexAnalyzerEnabled=false`); documented in the Makefile (Spring Boot's ~173 batches exceed Sonatype's authenticated free-tier rate limit → HTTP 401). NVD-only is correct here.
- *`JDK_VENDOR` unused build-arg warning* — rebuild confirmed **0 BuildKit warnings**; not actionable.

## Local verification (all green)
`make deps` · `make e2e` (kindest/node v1.36.1) · `make static-check` · `make renovate-validate` · `actionlint` · **`make ci-run` — 16 jobs succeeded, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)