### PR TITLE
feat(deploy): make the Carvel prod path a first-class, verified make target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ make run                   # Run locally (mvn spring-boot:run) at http://localho
 Quality / security gates:
 ```bash
 make format                # Apply google-java-format to Java sources
-make static-check          # Composite gate: format-check, lint, secrets, trivy-fs, trivy-config, lint-ci, mermaid-lint, deps-prune-check
+make static-check          # Composite gate: format-check, lint, secrets, trivy-fs, trivy-config, lint-ci, mermaid-lint, carvel-render-check, deps-prune-check
 make mermaid-lint          # Validate Mermaid diagrams in README.md / CLAUDE.md against minlag/mermaid-cli
 make cve-check             # OWASP dependency-check against NVD (canonical settings.xml flow; fast with NVD_API_KEY)
 make vulncheck             # Portfolio-standard alias for cve-check
@@ -110,10 +110,12 @@ Controllers use `@Value("${app.message:...}")` for configurable messages. On K8s
 
 ## Kubernetes Deployment
 
-Production path uses Carvel tools (ytt + kapp):
+Production path uses Carvel tools (ytt + kapp), wrapped by `make deploy`:
 ```bash
-ytt -f ./k8s | kapp deploy -y --into-ns spring-on-k8s -a spring-on-k8s -f-
+make deploy     # ytt -f ./k8s | kapp deploy -y --into-ns spring-on-k8s -a spring-on-k8s -f-
+make undeploy   # kapp delete -y -a spring-on-k8s
 ```
+`make deploy` guards on ytt/kapp presence (installed by `deps`, pinned in `.mise.toml`) and runs `carvel-render-check` first. **`carvel-render-check`** is a cluster-free gate (wired into `static-check`) asserting `ytt -f ./k8s` renders Namespace + ConfigMap + Deployment + Service — it keeps the Carvel path from silently rotting even though CI/e2e deploy via `kubectl` (`kind-deploy`). The `k8s/*.yml` manifests are currently plain YAML (no ytt templating), so ytt is passthrough here and **kapp** is the real value-add (app-grouping, GC, declarative diff); the render gate is in place for when ytt data-values/overlays are introduced. spring-on-k8s is the only portfolio repo using Carvel — every other k8s repo deploys with plain `kubectl apply`.
 
 K8s manifests in `k8s/`: namespace, deployment (1 replica, 1Gi memory, liveness/readiness probes), LoadBalancer service (80→8080), ConfigMap with `app.message`.
 

--- a/Makefile
+++ b/Makefile
@@ -261,11 +261,11 @@ deps-prune: deps
 deps-prune-check: deps
 	@mvn -B dependency:analyze -DignoreNonCompile=true -DfailOnWarning=true
 
-#static-check: @ Fast composite quality gate (format-check, lint, secrets, trivy-fs, trivy-config, lint-ci, mermaid-lint, deps-prune-check)
+#static-check: @ Fast composite quality gate (format-check, lint, secrets, trivy-fs, trivy-config, lint-ci, mermaid-lint, carvel-render-check, deps-prune-check)
 # vulncheck/cve-check is intentionally excluded — runs separately as a tag /
 # manual-dispatch job in CI. NVD slow path adds 10+ min when NVD_API_KEY is
 # absent, which would dominate every static-check run. See CLAUDE.md.
-static-check: format-check lint secrets trivy-fs trivy-config lint-ci mermaid-lint deps-prune-check
+static-check: format-check lint secrets trivy-fs trivy-config lint-ci mermaid-lint carvel-render-check deps-prune-check
 	@echo "All static checks passed. Run 'make cve-check' separately for vulnerability scan (slow)."
 
 #upgrade: @ Show available Maven dependency updates (dry-run)
@@ -508,6 +508,31 @@ kind-up: kind-create kind-setup kind-load kind-deploy
 
 #kind-down: @ Tear the full stack down (alias for kind-destroy)
 kind-down: kind-destroy
+
+# === Carvel production deploy (ytt render → kapp deploy) ===
+# The canonical production path (distinct from the local kubectl-based kind-deploy).
+# ytt + kapp are pinned in .mise.toml and installed by `deps`; the recipes still
+# guard on presence so a missing tool fails with a clear message, and
+# carvel-render-check (wired into static-check) keeps the path from silently
+# rotting even though CI/e2e deploy via kubectl. App name == namespace == APP_NAME.
+#deploy: @ Production deploy via Carvel (ytt render → kapp deploy) to the current kube-context
+deploy: deps carvel-render-check
+	@command -v kapp >/dev/null 2>&1 || { echo "ERROR: kapp not found — run 'make deps'"; exit 1; }
+	@ytt -f ./k8s | kapp deploy -y --into-ns $(APP_NAME) -a $(APP_NAME) -f-
+
+#undeploy: @ Remove the Carvel app from the current cluster (kapp delete)
+undeploy: deps
+	@command -v kapp >/dev/null 2>&1 || { echo "ERROR: kapp not found — run 'make deps'"; exit 1; }
+	@kapp delete -y -a $(APP_NAME)
+
+#carvel-render-check: @ Cluster-free gate: `ytt -f ./k8s` renders the expected K8s resources (guards the Carvel path)
+carvel-render-check: deps
+	@command -v ytt >/dev/null 2>&1 || { echo "ERROR: ytt not found — run 'make deps'"; exit 1; }
+	@ytt -f ./k8s > /dev/null
+	@for k in Namespace ConfigMap Deployment Service; do \
+		ytt -f ./k8s | grep -qE "^kind: $$k$$" || { echo "ERROR: rendered Carvel output missing kind: $$k"; exit 1; }; \
+	done
+	@echo "carvel-render-check: ytt renders Namespace + ConfigMap + Deployment + Service"
 
 #e2e: @ End-to-end test against KinD (spins up, tests, tears down)
 e2e: kind-up

--- a/README.md
+++ b/README.md
@@ -182,8 +182,11 @@ The CI `docker` job additionally runs an image scan (`aquasecurity/trivy-action`
 ### Production path (Carvel)
 
 ```bash
-ytt -f ./k8s | kapp deploy -y --into-ns spring-on-k8s -a spring-on-k8s -f-
+make deploy     # ytt -f ./k8s | kapp deploy -y --into-ns spring-on-k8s -a spring-on-k8s -f-
+make undeploy   # kapp delete -y -a spring-on-k8s
 ```
+
+`make deploy` guards on `ytt`/`kapp` presence (pinned in `.mise.toml`, installed by `make deps`) and runs `make carvel-render-check` first — a cluster-free gate (also in `make static-check`) that asserts `ytt -f ./k8s` renders the expected K8s resources, so the Carvel path can't silently rot. The manifests are plain YAML today (ytt is passthrough; **kapp** provides the app-grouping/GC/diff value).
 
 Wait for the `LoadBalancer` Service to receive an external IP:
 
@@ -277,7 +280,10 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make kind-up` | Bring the full stack up: create cluster → start cloud-provider-kind → load image → deploy |
+| `make deploy` | Production deploy via Carvel (`ytt -f ./k8s \| kapp deploy`) to the current kube-context; guards ytt/kapp presence + runs `carvel-render-check` |
+| `make undeploy` | Remove the Carvel app (`kapp delete -a spring-on-k8s`) |
+| `make carvel-render-check` | Cluster-free gate: `ytt -f ./k8s` renders Namespace + ConfigMap + Deployment + Service (also in `make static-check`) |
+| `make kind-up` | Bring the full stack up: create cluster → start cloud-provider-kind → load image → deploy (local path uses `kubectl apply`) |
 | `make kind-down` | Tear the cluster down |
 | `make kind-create` | Create KinD cluster (granular) |
 | `make kind-setup` | Start cloud-provider-kind for `LoadBalancer` IP allocation (granular) |


### PR DESCRIPTION
Per the review: Carvel (ytt+kapp) is unique to this repo and its `ytt | kapp` prod deploy was doc-only (no make target, no pre-req check, never run in CI/e2e → could silently rot).

- **`make deploy` / `make undeploy`** wrap the Carvel commands with ytt/kapp presence guards.
- **`make carvel-render-check`** — cluster-free gate (wired into `static-check`) asserting `ytt -f ./k8s` renders Namespace + ConfigMap + Deployment + Service. **Demonstrated RED** on a broken manifest, GREEN on valid.
- Docs note ytt is passthrough today (plain YAML → kapp is the real value-add) and that Carvel is non-standard portfolio-wide.

CI runs the new gate inside static-check; cve-check + docker skip (not a tag/release).