### PR TITLE
fix(makefile): pre-clean root-owned zap-output before dast-scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,7 @@ image-scan: deps
 
 #dast-scan: @ Run OWASP ZAP baseline against http://localhost:8080 (assumes container is running)
 dast-scan: deps
+	@rm -rf zap-output 2>/dev/null || docker run --rm --user 0 -v "$$PWD:/work" -w /work --entrypoint rm ghcr.io/zaproxy/zaproxy:$(ZAP_VERSION) -rf zap-output
 	@mkdir -p zap-output && chmod 777 zap-output
 	@docker run --rm --network host \
 		-v "$$PWD/zap-output:/zap/wrk:rw" \


### PR DESCRIPTION
The `dast-scan` target bind-mounts `zap-output` into the zaproxy container with **no `--user`**, so ZAP writes the DAST report as **root**. On the next run, the non-root host user cannot `chmod 777` the root-owned dir (`Operation not permitted`) and `make clean`'s `rm -rf ... zap-output` cannot unlink the root-owned files — both abort the recipe. It is invisible on the first run and trips on the second.

## Fix

Insert a root-capable pre-clean immediately before `mkdir -p zap-output && chmod 777 zap-output`:

```make
@rm -rf zap-output 2>/dev/null || docker run --rm --user 0 -v "$$PWD:/work" -w /work --entrypoint rm ghcr.io/zaproxy/zaproxy:$(ZAP_VERSION) -rf zap-output
```

The fallback runs as `--user 0` because the zaproxy image itself runs **non-root (uid 1000)**, so a plain `rm` container also cannot delete the root-owned files. This mirrors the repo's existing `--user $$(id -u):$$(id -g)` handling on the plantuml `diagrams` target.

This is Safety Check #17 (root-owned bind-mount output) from the `/makefile` skill. `dast-scan` is the only recipe with this pattern; `dast` reuses it via `$(MAKE) dast-scan`.

## Verification

- `make -n dast-scan` parses cleanly.
- RED→GREEN proven locally: created a root-owned `zap-output` (`docker run --user 0 ... chown -R 0:0`); a plain `rm -rf` failed as expected; the new pre-clean line (falling back to the `--user 0` container) removed it. Working tree clean afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)